### PR TITLE
Feature/Migrate prop test dashboard to greptime

### DIFF
--- a/zero-dashboards/dashboards/Commissioning/propulsion-test-dashboard.json
+++ b/zero-dashboards/dashboards/Commissioning/propulsion-test-dashboard.json
@@ -2956,10 +2956,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"Speed\").value ORDER BY time) AS external_speed,\r\n  LAST_VALUE((\"Torque\").value ORDER BY time) AS external_torque\r\nFROM marpower.externalmotor",
+          "rawSql": "SELECT\r\n  timestamp     AS time,\r\n  CASE WHEN '$aft_fwd' = 'AFT' THEN \"devices__can_aradex.i_aft_thrstr_speed_rpm\" ELSE \"devices__can_aradex.i_fwd_thrstr_speed_rpm\" END AS external_speed,\r\n  CASE WHEN '$aft_fwd' = 'AFT' THEN \"devices__can_aradex.i_aft_thrstr_torque_nm\" ELSE \"devices__can_aradex.i_fwd_thrstr_torque_nm\" END AS external_torque\r\nFROM public.prop_test__data\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "External motor",
           "sql": {
             "columns": [

--- a/zero-dashboards/dashboards/Commissioning/propulsion-test-dashboard.json
+++ b/zero-dashboards/dashboards/Commissioning/propulsion-test-dashboard.json
@@ -3441,9 +3441,23 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  'Aradex 1' AS device,\r\n  LAST_VALUE((\"Aradex_1_speed_feedback\").value ORDER BY time) AS speed,\r\n  LAST_VALUE((\"Aradex_1_torque_feedback\").value ORDER BY time) AS torque,\r\n  LAST_VALUE((\"SpeedorTorqueSetpointSignal(Aradex1)\").value ORDER BY time) AS torque_setpoint,\r\n  LAST_VALUE((\"Aradex1Temperature\").value ORDER BY time) AS temperature,\r\n  LAST_VALUE((\"Aradex1Flow\").value ORDER BY time) AS flow,\r\n  LAST_VALUE((\"Aradex1Pressure\").value ORDER BY time) AS pressure\r\nFROM marpower.thruster thruster\r\nWHERE topic = 'marpower/thruster/' || lower('$aft_fwd')\r\nUNION ALL\r\nSELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  'Aradex 2' AS device,\r\n  LAST_VALUE((\"Aradex_2_speed_feedback\").value ORDER BY time) AS speed,\r\n  LAST_VALUE((\"Aradex_2_torque_feedback\").value ORDER BY time) AS torque,\r\n  LAST_VALUE((\"SpeedorTorqueSetpointSignal(Aradex2)\").value ORDER BY time) AS torque_setpoint,\r\n  LAST_VALUE((\"Aradex2Temperature\").value ORDER BY time) AS temperature,\r\n  LAST_VALUE((\"Aradex2Flow\").value ORDER BY time) AS flow,\r\n  LAST_VALUE((\"Aradex2Pressure\").value ORDER BY time) AS pressure\r\nFROM marpower.thruster\r\nWHERE topic = 'marpower/thruster/' || lower('$aft_fwd')\r\nORDER BY device",
+          "rawSql": "WITH last_record AS (\r\n  SELECT *\r\n  FROM public.marpower__150000_propulsion\r\n  WHERE topic = 'marpower/150000-propulsion/pcs-' || lower('$aft_fwd')\r\n  ORDER BY timestamp DESC\r\n  LIMIT 1\r\n)\r\n\r\nSELECT\r\n  timestamp                     AS time,\r\n  'Aradex 1'                    AS device,\r\n  ara_1_speed__value            AS speed,\r\n  ara_1_torque__value           AS torque,\r\n  NULL                          AS torque_setpoint,\r\n  ara_1_temp_power_stage__value AS temperature,\r\n  NULL                          AS flow\r\nFROM last_record\r\n\r\nUNION ALL\r\n\r\nSELECT\r\n  timestamp                     AS time,\r\n  'Aradex 2'                    AS device,\r\n  ara_2_speed__value            AS speed,\r\n  ara_2_torque__value           AS torque,\r\n  NULL                          AS torque_setpoint,\r\n  ara_2_temp_power_stage__value AS temperature,\r\n  NULL                          AS flow\r\nFROM last_record\r\nORDER BY device",
           "refId": "A",
           "sql": {
             "columns": [
@@ -3600,9 +3614,23 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  time,\r\n  (\"Aradex_1_speed_feedback\").value  AS speed,\r\n  (\"Aradex_1_torque_feedback\").value AS torque\r\nFROM marpower.thruster\r\nwhere topic = 'marpower/thruster/' || lower('$aft_fwd')",
+          "rawSql": "SELECT\r\n  timestamp           AS time,\r\n  ara_1_speed__value  AS speed,\r\n  ara_1_torque__value AS torque\r\nFROM public.marpower__150000_propulsion\r\nWHERE topic = 'marpower/150000-propulsion/pcs-' || lower('$aft_fwd')\r\nAND $__timeFilter(timestamp)",
           "refId": "A",
           "sql": {
             "columns": [
@@ -3734,9 +3762,23 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  time,\r\n  (\"Aradex_2_speed_feedback\").value  AS speed,\r\n  (\"Aradex_2_torque_feedback\").value AS torque\r\nFROM marpower.thruster\r\nwhere topic = 'marpower/thruster/' || lower('$aft_fwd')",
+          "rawSql": "SELECT\r\n  timestamp           AS time,\r\n  ara_2_speed__value  AS speed,\r\n  ara_2_torque__value AS torque\r\nFROM public.marpower__150000_propulsion\r\nWHERE topic = 'marpower/150000-propulsion/pcs-' || lower('$aft_fwd')\r\nAND $__timeFilter(timestamp)",
           "refId": "A",
           "sql": {
             "columns": [

--- a/zero-dashboards/dashboards/Commissioning/propulsion-test-dashboard.json
+++ b/zero-dashboards/dashboards/Commissioning/propulsion-test-dashboard.json
@@ -18,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 16,
+  "id": 12,
   "links": [
     {
       "asDropdown": true,
@@ -4308,32 +4308,7 @@
           },
           "unit": "celsius"
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "forepeak_tempsensor"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "celsius"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "tank_level"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "percent"
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 5,
@@ -4996,9 +4971,23 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  CASE WHEN '$aft_fwd' = 'AFT'\r\n    THEN LAST_VALUE((\"AFT_THRUST_WINDINGTEMPU1\").value ORDER BY time)\r\n    ELSE LAST_VALUE((\"FWD_THRUST_WINDINGTEMPU1\").value ORDER BY time)\r\n    END AS winding_temp_u1,\r\n  CASE WHEN '$aft_fwd' = 'AFT'\r\n    THEN LAST_VALUE((\"AFT_THRUST_WINDINGTEMPV1\").value ORDER BY time)\r\n    ELSE LAST_VALUE((\"FWD_THRUST_WINDINGTEMPU1\").value ORDER BY time)\r\n    END AS winding_temp_v1,\r\n  CASE WHEN '$aft_fwd' = 'AFT'\r\n    THEN LAST_VALUE((\"AFT_THRUST_WINDINGTEMPW1\").value ORDER BY time)\r\n    ELSE LAST_VALUE((\"FWD_THRUST_WINDING_TEMP_W1\").value ORDER BY time)\r\n    END AS winding_temp_w1,\r\n  CASE WHEN '$aft_fwd' = 'AFT'\r\n    THEN LAST_VALUE((\"AFT_THRUST_WINDINGTEMPU2\").value ORDER BY time)\r\n    ELSE LAST_VALUE((\"BOW_THRUST_WINDINGTEMPU2\").value ORDER BY time)\r\n    END AS winding_temp_u2,\r\n  CASE WHEN '$aft_fwd' = 'AFT'\r\n    THEN LAST_VALUE((\"AFT_THRUST_WINDINGTEMPV2\").value ORDER BY time)\r\n    ELSE LAST_VALUE((\"BOW_THRUST_WINDINGTEMPV2\").value ORDER BY time)\r\n    END AS winding_temp_v2,\r\n  CASE WHEN '$aft_fwd' = 'AFT'\r\n    THEN LAST_VALUE((\"AFT_THRUST_WINDINGTEMPW2\").value ORDER BY time)\r\n    ELSE LAST_VALUE((\"BOW_THRUST_WINDINGTEMPW2\").value ORDER BY time)\r\n    END AS winding_temp_w2,\r\n  CASE WHEN '$aft_fwd' = 'AFT'\r\n    THEN LAST_VALUE((\"STERN_THRUST_BEARING_DE_TEMP\").value ORDER BY time)\r\n    ELSE LAST_VALUE((\"BOW_THRUST_BEARING_DE_TEMP\").value ORDER BY time)\r\n    END AS bearing_de_temp,\r\n  CASE WHEN '$aft_fwd' = 'AFT'\r\n    THEN LAST_VALUE((\"STERN_THRUST_BEARING_NDE_TEMP\").value ORDER BY time)\r\n    ELSE LAST_VALUE((\"BOW_THRUST_BEARING_NDE_TEMP\").value ORDER BY time)\r\n    END AS bearing_nde_temp\r\nFROM marpower.\"150000_propulsion_general\"",
+          "rawSql": "SELECT\r\n  timestamp AS time,\r\n  CASE WHEN '$aft_fwd' = 'AFT'\r\n    THEN aft_thrust_windingtempu_1__value\r\n    ELSE fwd_thrust_windingtempu_1__value\r\n  END AS winding_temp_u1,\r\n  CASE WHEN '$aft_fwd' = 'AFT'\r\n    THEN aft_thrust_windingtempv_1__value\r\n    ELSE fwd_thrust_windingtempv_1__value\r\n  END AS winding_temp_v1,\r\n  CASE WHEN '$aft_fwd' = 'AFT'\r\n    THEN aft_thrust_windingtempw_1__value\r\n    ELSE fwd_thrust_winding_temp_w_1__value\r\n  END AS winding_temp_w1,\r\n  CASE WHEN '$aft_fwd' = 'AFT'\r\n    THEN aft_thrust_windingtempu_2__value\r\n    ELSE bow_thrust_windingtempu_2__value\r\n  END AS winding_temp_u2,\r\n  CASE WHEN '$aft_fwd' = 'AFT'\r\n    THEN aft_thrust_windingtempv_2__value\r\n    ELSE bow_thrust_windingtempv_2__value\r\n  END AS winding_temp_v2,\r\n  CASE WHEN '$aft_fwd' = 'AFT'\r\n    THEN aft_thrust_windingtempw_2__value\r\n    ELSE bow_thrust_windingtempw_2__value\r\n  END AS winding_temp_w2,\r\n  CASE WHEN '$aft_fwd' = 'AFT'\r\n    THEN stern_thrust_bearing_de_temp__value\r\n    ELSE bow_thrust_bearing_de_temp__value\r\n  END AS bearing_de_temp,\r\n  CASE WHEN '$aft_fwd' = 'AFT'\r\n    THEN stern_thrust_bearing_nde_temp__value\r\n    ELSE bow_thrust_bearing_nde_temp__value\r\n  END AS bearing_nde_temp\r\nFROM public.marpower__150000_propulsion_general\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -6144,7 +6133,7 @@
         },
         "name": "datasource",
         "options": [],
-        "query": "grafana-postgresql-datasource",
+        "query": "info8fcc-greptimedb-datasource",
         "refresh": 1,
         "regex": "",
         "type": "datasource"
@@ -6201,5 +6190,5 @@
   "timezone": "browser",
   "title": "Propulsion test",
   "uid": "commissioning-propulsion-test",
-  "version": 3
+  "version": 1
 }


### PR DESCRIPTION
Migrated Propulsion test dashboard to use Greptime DB instead of RisingWave.
Because not all data is present in Greptime DB and the dashboard also needs some updates, which will involve removing some data points, this migration is done only partial.

The following dashboard panels/visualizations are migrated:
- Mechanical:
  - External motor (Emrax) speed + torque values (this panel now also switches between FWD and AFT based on the value selected at the top of the dashboard)
  - Aradex data table
  - Aradex 1 speed + torque graph
  - Aradex 2 speed + torque graph
- Cooling circuit (previously: Temperatures):
  - Internal thruster temperatures



[ZERO-1708](https://foundationzero-team.atlassian.net/browse/ZERO-1708)

[ZERO-1708]: https://foundationzero-team.atlassian.net/browse/ZERO-1708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ