### PR TITLE
Move linux user to dockerfile & simplify deployments

### DIFF
--- a/zero-domestic-control/Dockerfile
+++ b/zero-domestic-control/Dockerfile
@@ -6,7 +6,6 @@ ENV POETRY_VERSION=2.2.1 \
     POETRY_NO_INTERACTION=1 \
     POETRY_VIRTUALENVS_IN_PROJECT=1 \
     POETRY_VIRTUALENVS_CREATE=1 \
-    # Nice to have optimizations
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=on
@@ -26,10 +25,15 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 ENV VIRTUAL_ENV=/app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
 
-COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
+RUN groupadd -g 1001 app && \
+    useradd -r -u 1001 -g app app
+
+COPY --chown=1001:1001 --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 
 WORKDIR /app
 
-COPY src/domestic_control/ domestic_control/
+COPY --chown=1001:1001 src/domestic_control/ domestic_control/
+
+USER 1001
 
 ENTRYPOINT ["python", "-m", "domestic_control"]

--- a/zero-domestic-control/charts/zero-domestic-control/templates/backend-dpl.yaml
+++ b/zero-domestic-control/charts/zero-domestic-control/templates/backend-dpl.yaml
@@ -33,10 +33,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
-        fsGroupChangePolicy: Always
-        sysctls: []
-        supplementalGroups: []
         fsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: domestic-control-backend
           securityContext:
@@ -44,14 +43,8 @@ spec:
             capabilities:
               drop:
               - ALL
-            privileged: false
             readOnlyRootFilesystem: true
-            runAsGroup: 1001
             runAsNonRoot: true
-            runAsUser: 1001
-            seLinuxOptions: {}
-            seccompProfile:
-              type: RuntimeDefault
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["fastapi", "run", "/app/domestic_control/app.py", "--host", "0.0.0.0", "--port", "{{ .Values.service.backend.containerPort }}"]

--- a/zero-domestic-control/charts/zero-domestic-control/templates/control-dpl.yaml
+++ b/zero-domestic-control/charts/zero-domestic-control/templates/control-dpl.yaml
@@ -33,10 +33,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
-        fsGroupChangePolicy: Always
-        sysctls: []
-        supplementalGroups: []
         fsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: domestic-control
           securityContext:
@@ -44,14 +43,8 @@ spec:
             capabilities:
               drop:
               - ALL
-            privileged: false
             readOnlyRootFilesystem: true
-            runAsGroup: 1001
             runAsNonRoot: true
-            runAsUser: 1001
-            seLinuxOptions: {}
-            seccompProfile:
-              type: RuntimeDefault
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["python", "-m", "domestic_control", "control"]

--- a/zero-loads-app/Dockerfile
+++ b/zero-loads-app/Dockerfile
@@ -28,9 +28,11 @@ FROM python:3.13-slim-bookworm AS runtime
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
-
 ENV VIRTUAL_ENV=/app/zero-loads-app/.venv
 ENV PATH="/app/zero-loads-app/.venv/bin:$PATH"
+
+RUN groupadd -g 1001 app && \
+    useradd -r -u 1001 -g app app
 
 COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 

--- a/zero-loads-app/Dockerfile
+++ b/zero-loads-app/Dockerfile
@@ -34,14 +34,15 @@ ENV PATH="/app/zero-loads-app/.venv/bin:$PATH"
 RUN groupadd -g 1001 app && \
     useradd -r -u 1001 -g app app
 
-COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
+COPY --from=builder --chown=1001:1001 ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 
 WORKDIR /app
 
-COPY zero-generator/ zero-generator/
-COPY zero-loads-app/src/ ./zero-loads-app
+COPY --chown=1001:1001 zero-generator/ zero-generator/
+COPY --chown=1001:1001 zero-loads-app/src/ ./zero-loads-app
 
 WORKDIR /app/zero-loads-app
+USER 1001
 
 ENTRYPOINT ["python", "-m", "loads"]
 CMD ["api"]

--- a/zero-loads-app/charts/templates/api/deployment-api.yaml
+++ b/zero-loads-app/charts/templates/api/deployment-api.yaml
@@ -32,10 +32,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
-        fsGroupChangePolicy: Always
-        sysctls: []
-        supplementalGroups: []
         fsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: loads
           command: ["uvicorn", "loads.api.api:app", "--host", "0.0.0.0", "--port", "5101"]
@@ -44,21 +43,14 @@ spec:
             capabilities:
               drop:
               - ALL
-            privileged: false
             readOnlyRootFilesystem: true
-            runAsGroup: 1001
             runAsNonRoot: true
-            runAsUser: 1001
-            seLinuxOptions: {}
-            seccompProfile:
-              type: RuntimeDefault
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
               containerPort: 5101
               protocol: TCP
-          
           livenessProbe:
             httpGet:
               path: /health/live
@@ -67,7 +59,6 @@ spec:
             httpGet:
               path: /health/ready
               port: http
-          
           {{- with .Values.api.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -83,7 +74,7 @@ spec:
               value: {{ .Values.postgresql.user | quote }}
             - name: PG_PASSWORD
               valueFrom:
-                secretKeyRef: 
+                secretKeyRef:
                   name: {{ .Values.postgresql.existingSecret }}
                   key: {{ .Values.postgresql.existingSecretPasswordKey }}
             - name: PG_DB
@@ -96,7 +87,7 @@ spec:
               value: {{ .Values.mqtt.username | quote }}
             - name: MQTT_PASSWORD
               valueFrom:
-                secretKeyRef: 
+                secretKeyRef:
                   name: {{ .Values.mqtt.existingSecret }}
                   key: {{ .Values.mqtt.existingSecretPasswordKey }}
       {{- with .Values.api.nodeSelector }}

--- a/zero-loads-app/charts/templates/stub/deployment-stub.yaml
+++ b/zero-loads-app/charts/templates/stub/deployment-stub.yaml
@@ -33,10 +33,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
-        fsGroupChangePolicy: Always
-        sysctls: []
-        supplementalGroups: []
         fsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: sensor-stub
           command: ["python", "-m", "loads", "sensors-stub"]
@@ -45,17 +44,10 @@ spec:
             capabilities:
               drop:
               - ALL
-            privileged: false
             readOnlyRootFilesystem: true
-            runAsGroup: 1001
             runAsNonRoot: true
-            runAsUser: 1001
-            seLinuxOptions: {}
-            seccompProfile:
-              type: RuntimeDefault
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          
           {{- with .Values.sensorStub.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -71,7 +63,7 @@ spec:
               value: {{ .Values.postgresql.user | quote }}
             - name: PG_PASSWORD
               valueFrom:
-                secretKeyRef: 
+                secretKeyRef:
                   name: {{ .Values.postgresql.existingSecret }}
                   key: {{ .Values.postgresql.existingSecretPasswordKey }}
             - name: PG_DB
@@ -84,7 +76,7 @@ spec:
               value: {{ .Values.mqtt.username | quote }}
             - name: MQTT_PASSWORD
               valueFrom:
-                secretKeyRef: 
+                secretKeyRef:
                   name: {{ .Values.mqtt.existingSecret }}
                   key: {{ .Values.mqtt.existingSecretPasswordKey }}
 

--- a/zero-thrs-control/Dockerfile
+++ b/zero-thrs-control/Dockerfile
@@ -25,11 +25,14 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 ENV VIRTUAL_ENV=/app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
 
-COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
+RUN groupadd -g 1001 app && \
+    useradd -r -u 1001 -g app app
+
+COPY --chown=1001:1001 --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 
 WORKDIR /app
 
-COPY ./src/thrs/ thrs/
+COPY --chown=1001:1001 ./src/thrs/ thrs/
 
 FROM prod-base AS simulation
 
@@ -38,7 +41,10 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN fmpy compile /app/thrs/simulation/models/thruster_moduleV18.fmu
+
+USER 1001
 CMD ["python", "-m", "thrs.cli", "run", "thrusters"]
 
 FROM prod-base AS control
+USER 1001
 CMD ["uvicorn", "thrs.graphql.strawberry:app", "--port", "5102", "--host", "0.0.0.0"]

--- a/zero-thrs-control/charts/zero-thrs-control/templates/control-deployment.yaml
+++ b/zero-thrs-control/charts/zero-thrs-control/templates/control-deployment.yaml
@@ -24,25 +24,18 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
-        fsGroupChangePolicy: Always
-        sysctls: []
-        supplementalGroups: []
         fsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: thrs-control
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            privileged: false
-            readOnlyRootFilesystem: true
-            runAsGroup: 1001
-            runAsNonRoot: true
-            runAsUser: 1001
-            seLinuxOptions: {}
-            seccompProfile:
-              type: RuntimeDefault
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
           image: "{{ .Values.control.image.repository }}:{{ .Values.control.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.control.image.pullPolicy }}
           ports:

--- a/zero-thrs-control/charts/zero-thrs-control/templates/simulation-deployment.yaml
+++ b/zero-thrs-control/charts/zero-thrs-control/templates/simulation-deployment.yaml
@@ -27,10 +27,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
-        fsGroupChangePolicy: Always
-        sysctls: []
-        supplementalGroups: []
         fsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: thrs-control
           securityContext:
@@ -38,14 +37,8 @@ spec:
             capabilities:
               drop:
               - ALL
-            privileged: false
             readOnlyRootFilesystem: true
-            runAsGroup: 1001
             runAsNonRoot: true
-            runAsUser: 1001
-            seLinuxOptions: {}
-            seccompProfile:
-              type: RuntimeDefault
           image: "{{ .Values.simulation.image.repository }}:{{ .Values.simulation.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.simulation.image.pullPolicy }}
           resources:

--- a/zero-ui/charts/templates/deployment.yaml
+++ b/zero-ui/charts/templates/deployment.yaml
@@ -32,26 +32,18 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
-        fsGroupChangePolicy: Always
-        sysctls: []
-        supplementalGroups: []
-        fsGroup: 1001
+        fsGroup: 101
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: ui
           securityContext:
-            securityContext:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
               - ALL
-            privileged: false
             readOnlyRootFilesystem: true
-            runAsGroup: 1001
             runAsNonRoot: true
-            runAsUser: 1001
-            seLinuxOptions: {}
-            seccompProfile:
-              type: RuntimeDefault
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
@@ -80,7 +72,7 @@ spec:
         - name: config
           configMap:
             name: {{ include "..fullname" . }}-config
-            items: 
+            items:
               - key: env.json
                 path: env.json
         - emptyDir: {}


### PR DESCRIPTION
The root cause of the deployment faillure of domestic control on all clusters was [this issue in aiomysql](https://github.com/aio-libs/aiomysql/issues/1053). I took this opportunity to clean up our deployments:
- Move default linux user to dockerfile so it is a default
- Remove user id related config from k8s
- Remove default and unnecessary securityContext config from k8s

Do these changes for:
- Domestic control
- Loads App
- THRS
- UI (only k8s changes, Dockerfile uses nginx(101) user

ZERO-1778