### PR TITLE
Migrate PMS dashboard to Greptime DB

### DIFF
--- a/zero-dashboards/dashboards/Commissioning/pms-dashboard.json
+++ b/zero-dashboards/dashboards/Commissioning/pms-dashboard.json
@@ -36001,10 +36001,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"ERROR\").value ORDER BY time)     AS error,\r\n  LAST_VALUE((\"OVERLOAD\").value ORDER BY time)  AS overload,\r\n  LAST_VALUE((\"ONLINE\").value ORDER BY time)    AS status_online,\r\n  LAST_VALUE((\"AVAILABLE\").value ORDER BY time) AS status_available\r\nFROM marpower.\"450000_dc_distribution_esi\"\r\nWHERE topic = 'marpower/450000-dc-distribution/esi/keb6'",
+          "rawSql": "SELECT\r\n  timestamp          AS time,\r\n  error__value       AS error,\r\n  overload__value    AS overload,\r\n  online__value      AS status_online,\r\n  available__value   AS status_available\r\nFROM public.marpower__450000_dc_distribution__esi\r\nWHERE topic = 'marpower/450000-dc-distribution/esi/keb6'\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -36031,10 +36045,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"KEB6_ESI_PS_EMERGSWITCHOFF1\").value ORDER BY time) AS control_em_switch1_off,\r\n  LAST_VALUE((\"KEB6_ESI_PS_EMERGSWITCHOFF2\").value ORDER BY time) AS control_em_switch2_off\r\nFROM marpower.\"450000_dc_distribution_general\"",
+          "rawSql": "SELECT\r\n  timestamp                                     AS time,\r\n  NULL AS control_em_switch1_off,\r\n  NULL AS control_em_switch2_off\r\nFROM public.marpower__450000_dc_distribution_general\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "B",
           "sql": {
             "columns": [
@@ -36647,10 +36675,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"ERROR\").value ORDER BY time)     AS error,\r\n  LAST_VALUE((\"OVERLOAD\").value ORDER BY time)  AS overload,\r\n  LAST_VALUE((\"ONLINE\").value ORDER BY time)    AS status_online,\r\n  LAST_VALUE((\"AVAILABLE\").value ORDER BY time) AS status_available\r\nFROM marpower.\"450000_dc_distribution_esi\"\r\nWHERE topic = 'marpower/450000-dc-distribution/esi/keb7'",
+          "rawSql": "SELECT\r\n  timestamp          AS time,\r\n  error__value       AS error,\r\n  overload__value    AS overload,\r\n  online__value      AS status_online,\r\n  available__value   AS status_available\r\nFROM public.marpower__450000_dc_distribution__esi\r\nWHERE topic = 'marpower/450000-dc-distribution/esi/keb7'\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -37339,9 +37381,23 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"KEB6_SB08_TEMP\").value ORDER BY time)        AS sb08,\r\n  LAST_VALUE((\"KEB6_MSB_AFT_TEMPP01\").value ORDER BY time)  AS msb_aft1,\r\n  LAST_VALUE((\"KEB6_MSB_AFT_TEMPP02\").value ORDER BY time)  AS msb_aft2,\r\n  LAST_VALUE((\"KEB7_MSB_AFT_P03_TEMP\").value ORDER BY time) AS msb_aft3,\r\n  LAST_VALUE((\"KEB7_MSB_AFT_P04_TEMP\").value ORDER BY time) AS msb_aft4,\r\n  LAST_VALUE((\"KEB8_FWD_SB02_TEMPP01\").value ORDER BY time) AS sb02_fwd1,\r\n  LAST_VALUE((\"KEB8_FWD_SB02_TEMPP02\").value ORDER BY time) AS sb02_fwd2\r\nFROM marpower.\"450000_dc_distribution_general\"",
+          "rawSql": "SELECT\r\n  timestamp                       AS time,\r\n  keb_6_sb_08_temp__value         AS sb08,\r\n  keb_6_msb_aft_tempp_01__value   AS msb_aft1,\r\n  keb_6_msb_aft_tempp_02__value   AS msb_aft2,\r\n  keb_7_msb_aft_p_03_temp__value  AS msb_aft3,\r\n  keb_7_msb_aft_p_04_temp__value  AS msb_aft4,\r\n  keb_8_fwd_sb_02_tempp_01__value AS sb02_fwd1,\r\n  keb_8_fwd_sb_02_tempp_02__value AS sb02_fwd2\r\nFROM public.marpower__450000_dc_distribution_general\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [

--- a/zero-dashboards/dashboards/Commissioning/pms-dashboard.json
+++ b/zero-dashboards/dashboards/Commissioning/pms-dashboard.json
@@ -12527,10 +12527,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"AUTOMODE\").value ORDER BY time)           AS automode,\r\n  LAST_VALUE((\"BREAKEROPENED\").value ORDER BY time)      AS breaker_opened,\r\n  LAST_VALUE((\"BREAKERCLOSED\").value ORDER BY time)      AS breaker_closed,\r\n  LAST_VALUE((\"SYNCRODEVICESTATUS\").value ORDER BY time) AS sync_status,\r\n  LAST_VALUE((\"SYNCROSPEEDUP\").value ORDER BY time)      AS sync_speed_up,\r\n  LAST_VALUE((\"SYNCROSPEEDDOWN\").value ORDER BY time)    AS sync_speed_down,\r\n  LAST_VALUE((\"ROTATINGFIELD\").value ORDER BY time)      AS rotation_field\r\nFROM marpower.\"450000_dynamic_conv_ps_general\"",
+          "rawSql": "SELECT\r\n  timestamp                 AS time,\r\n  automode__value           AS automode,\r\n  breakeropened__value      AS breaker_opened,\r\n  breakerclosed__value      AS breaker_closed,\r\n  syncrodevicestatus__value AS sync_status,\r\n  syncrospeedup__value      AS sync_speed_up,\r\n  syncrospeeddown__value    AS sync_speed_down,\r\n  rotatingfield__value      AS rotation_field\r\nFROM public.marpower__450000_dynamic_conv_ps_general\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -13032,9 +13046,23 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"SYNCCOMM\").value ORDER BY time)     AS sync_cmd,\r\n  LAST_VALUE((\"OPENCBCOMM\").value ORDER BY time)   AS open_breaker_cmd,\r\n  LAST_VALUE((\"NONPREFTRIP1\").value ORDER BY time) AS non_pref_trip1,\r\n  LAST_VALUE((\"NONPREFTRIP2\").value ORDER BY time) AS non_pref_trip2,\r\n  LAST_VALUE((\"NONPREFTRIP3\").value ORDER BY time) AS non_pref_trip3\r\nFROM marpower.\"450000_dynamic_conv_ps_general\"",
+          "rawSql": "SELECT\r\n  timestamp              AS time,\r\n  synccomm__value        AS sync_cmd,\r\n  opencbcomm__value      AS open_breaker_cmd,\r\n  nonpreftrip_1__value   AS non_pref_trip1,\r\n  nonpreftrip_2__value   AS non_pref_trip2,\r\n  nonpreftrip_3__value   AS non_pref_trip3\r\nFROM public.marpower__450000_dynamic_conv_ps_general\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -13298,9 +13326,23 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"BREAKERTRIPPED\").value ORDER BY time)     AS breaker_tripped,\r\n  LAST_VALUE((\"CONTROLFAILURE\").value ORDER BY time)     AS control_failure\r\nFROM marpower.\"450000_dynamic_conv_ps_general\"",
+          "rawSql": "SELECT\r\n  timestamp             AS time,\r\n  breakertripped__value AS breaker_tripped,\r\n  controlfailure__value AS control_failure\r\nFROM public.marpower__450000_dynamic_conv_ps_general\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -13321,7 +13363,7 @@
           }
         }
       ],
-      "title": "Alamrs - AC Grid - PS",
+      "title": "Alarms - AC Grid - PS",
       "type": "canvas"
     },
     {
@@ -13971,10 +14013,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"AUTOMODE\").value ORDER BY time)           AS automode,\r\n  LAST_VALUE((\"BREAKEROPENED\").value ORDER BY time)      AS breaker_opened,\r\n  LAST_VALUE((\"BREAKERCLOSED\").value ORDER BY time)      AS breaker_closed,\r\n  LAST_VALUE((\"SYNCRODEVICESTATUS\").value ORDER BY time) AS sync_status,\r\n  LAST_VALUE((\"SYNCROSPEEDUP\").value ORDER BY time)      AS sync_speed_up,\r\n  LAST_VALUE((\"SYNCROSPEEDDOWN\").value ORDER BY time)    AS sync_speed_down,\r\n  LAST_VALUE((\"ROTATINGFIELD\").value ORDER BY time)      AS rotation_field\r\nFROM marpower.\"450000_dynamic_conv_sb_general\"",
+          "rawSql": "SELECT\r\n  timestamp                 AS time,\r\n  automode__value           AS automode,\r\n  breakeropened__value      AS breaker_opened,\r\n  breakerclosed__value      AS breaker_closed,\r\n  syncrodevicestatus__value AS sync_status,\r\n  syncrospeedup__value      AS sync_speed_up,\r\n  syncrospeeddown__value    AS sync_speed_down,\r\n  rotatingfield__value      AS rotation_field\r\nFROM public.marpower__450000_dynamic_conv_sb_general\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -14476,9 +14532,23 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"SYNCCOMM\").value ORDER BY time)     AS sync_cmd,\r\n  LAST_VALUE((\"OPENCBCOMM\").value ORDER BY time)   AS open_breaker_cmd,\r\n  LAST_VALUE((\"NONPREFTRIP4\").value ORDER BY time) AS non_pref_trip1,\r\n  LAST_VALUE((\"NONPREFTRIP5\").value ORDER BY time) AS non_pref_trip2,\r\n  LAST_VALUE((\"NONPREFTRIP6\").value ORDER BY time) AS non_pref_trip3\r\nFROM marpower.\"450000_dynamic_conv_sb_general\"",
+          "rawSql": "SELECT\r\n  timestamp            AS time,\r\n  synccomm__value      AS sync_cmd,\r\n  opencbcomm__value    AS open_breaker_cmd,\r\n  nonpreftrip_4__value AS non_pref_trip1,\r\n  nonpreftrip_5__value AS non_pref_trip2,\r\n  nonpreftrip_6__value AS non_pref_trip3\r\nFROM public.marpower__450000_dynamic_conv_sb_general\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -14742,9 +14812,23 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"BREAKERTRIPPED\").value ORDER BY time)     AS breaker_tripped,\r\n  LAST_VALUE((\"CONTROLFAILURE\").value ORDER BY time)     AS control_failure\r\nFROM marpower.\"450000_dynamic_conv_sb_general\"",
+          "rawSql": "SELECT\r\n  timestamp             AS time,\r\n  breakertripped__value AS breaker_tripped,\r\n  controlfailure__value AS control_failure\r\nFROM public.marpower__450000_dynamic_conv_sb_general\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -14765,7 +14849,7 @@
           }
         }
       ],
-      "title": "Alamrs - AC Grid - SB",
+      "title": "Alarms - AC Grid - SB",
       "type": "canvas"
     },
     {
@@ -15008,9 +15092,23 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"ACGRID_BUSTIEOPENED\").value ORDER BY time)     AS bustie_opened,\r\n  LAST_VALUE((\"ACGRID_BUSTIECLOSED\").value ORDER BY time)     AS bustie_closed\r\nFROM marpower.\"450000_dynamic_conv\"",
+          "rawSql": "SELECT\r\n  timestamp                  AS time,\r\n  acgrid_bustieopened__value AS bustie_opened,\r\n  acgrid_bustieclosed__value AS bustie_closed\r\nFROM public.marpower__450000_dynamic_conv\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -15709,9 +15807,23 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"TOTALACTIVEPOWER\").value ORDER BY time)    AS active_power,\r\n  LAST_VALUE((\"TOTALREACTIVEPOWER\").value ORDER BY time)  AS reactive_power,\r\n  LAST_VALUE((\"TOTALAPPARENTPOWER\").value ORDER BY time)  AS apparent_power,\r\n  LAST_VALUE((\"TOTALACTIVEENERGY\").value ORDER BY time)   AS active_energy,\r\n  LAST_VALUE((\"TOTALREACTIVEENERGY\").value ORDER BY time) AS reactive_energy,\r\n  LAST_VALUE((\"TOTALAPPARENTENERGY\").value ORDER BY time) AS apparent_energy,\r\n  LAST_VALUE((\"TOTALPOWERFACTOR\").value ORDER BY time)    AS power_factor\r\nFROM marpower.\"450000_dynamic_conv_ps_general\"",
+          "rawSql": "SELECT\r\n  timestamp                   AS time,\r\n  \"totalactivepower __value\"  AS active_power,\r\n  totalreactivepower__value   AS reactive_power,\r\n  totalapparentpower__value   AS apparent_power,\r\n  totalactiveenergy__value    AS active_energy,\r\n  totalreactiveenergy__value  AS reactive_energy,\r\n  totalapparentenergy__value  AS apparent_energy,\r\n  totalpowerfactor__value     AS power_factor\r\nFROM public.marpower__450000_dynamic_conv_ps_general\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -16410,9 +16522,23 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"TOTALACTIVEPOWER\").value ORDER BY time)    AS active_power,\r\n  LAST_VALUE((\"TOTALREACTIVEPOWER\").value ORDER BY time)  AS reactive_power,\r\n  LAST_VALUE((\"TOTALAPPARENTPOWER\").value ORDER BY time)  AS apparent_power,\r\n  LAST_VALUE((\"TOTALACTIVEENERGY\").value ORDER BY time)   AS active_energy,\r\n  LAST_VALUE((\"TOTALREACTIVEENERGY\").value ORDER BY time) AS reactive_energy,\r\n  LAST_VALUE((\"TOTALAPPARENTENERGY\").value ORDER BY time) AS apparent_energy,\r\n  LAST_VALUE((\"TOTALPOWERFACTOR\").value ORDER BY time)    AS power_factor,\r\n  LAST_VALUE((\"ROTATINGFIELD\").value ORDER BY time)       AS rotation_field\r\nFROM marpower.\"450000_dynamic_conv_sb_general\"",
+          "rawSql": "SELECT\r\n  timestamp                   AS time,\r\n  totalactivepower__value     AS active_power,\r\n  totalreactivepower__value   AS reactive_power,\r\n  totalapparentpower__value   AS apparent_power,\r\n  totalactiveenergy__value    AS active_energy,\r\n  totalreactiveenergy__value  AS reactive_energy,\r\n  totalapparentenergy__value  AS apparent_energy,\r\n  totalpowerfactor__value     AS power_factor,\r\n  rotatingfield__value        AS rotation_field\r\nFROM public.marpower__450000_dynamic_conv_sb_general\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -17621,9 +17747,23 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"CURRENT\").value ORDER BY time)       AS current,\r\n  LAST_VALUE((\"OVERCURRENT\").value ORDER BY time)   AS over_current,\r\n  LAST_VALUE((\"VOLTAGE\").value ORDER BY time)       AS voltage,\r\n  LAST_VALUE((\"UNDERVOLTAGE\").value ORDER BY time)  AS under_voltage,\r\n  LAST_VALUE((\"OVERVOLTAGE\").value ORDER BY time)   AS over_voltage,\r\n  LAST_VALUE((\"ACTIVEPOWER\").value ORDER BY time)   AS active_power,\r\n  LAST_VALUE((\"REACTIVEPOWER\").value ORDER BY time) AS reactive_power,\r\n  LAST_VALUE((\"APPARENTPOWER\").value ORDER BY time) AS apparent_power,\r\n  LAST_VALUE((\"COSPHI\").value ORDER BY time)        AS cos_phi,\r\n  LAST_VALUE((\"POWERFACTOR\").value ORDER BY time)   AS power_factor,\r\n  LAST_VALUE((\"FREQUENCY\").value ORDER BY time)     AS frequency,\r\n  LAST_VALUE((\"NOZERO\").value ORDER BY time)        AS no_zero,\r\n  LAST_VALUE((\"VOLTAGESAG\").value ORDER BY time)    AS voltage_sag,\r\n  LAST_VALUE((\"4QUADRANT\").value ORDER BY time)     AS four_quadrant\r\nFROM marpower.\"450000_dynamic_conv_ps\"\r\nwhere topic = 'marpower/450000-dynamic-conv-ps/ch1'",
+          "rawSql": "SELECT\r\n  timestamp               AS time,\r\n  current__value          AS current,\r\n  overcurrent__value      AS over_current,\r\n  voltage__value          AS voltage,\r\n  undervoltage__value     AS under_voltage,\r\n  overvoltage__value      AS over_voltage,\r\n  activepower__value      AS active_power,\r\n  reactivepower__value    AS reactive_power,\r\n  apparentpower__value    AS apparent_power,\r\n  cosphi__value           AS cos_phi,\r\n  powerfactor__value      AS power_factor,\r\n  frequency__value        AS frequency,\r\n  nozero__value           AS no_zero,\r\n  voltagesag__value       AS voltage_sag,\r\n  \"4_quadrant__value\"       AS four_quadrant\r\nFROM public.marpower__450000_dynamic_conv_ps\r\nWHERE topic = 'marpower/450000-dynamic-conv-ps/ch1'\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -18832,9 +18972,23 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"CURRENT\").value ORDER BY time)       AS current,\r\n  LAST_VALUE((\"OVERCURRENT\").value ORDER BY time)   AS over_current,\r\n  LAST_VALUE((\"VOLTAGE\").value ORDER BY time)       AS voltage,\r\n  LAST_VALUE((\"UNDERVOLTAGE\").value ORDER BY time)  AS under_voltage,\r\n  LAST_VALUE((\"OVERVOLTAGE\").value ORDER BY time)   AS over_voltage,\r\n  LAST_VALUE((\"ACTIVEPOWER\").value ORDER BY time)   AS active_power,\r\n  LAST_VALUE((\"REACTIVEPOWER\").value ORDER BY time) AS reactive_power,\r\n  LAST_VALUE((\"APPARENTPOWER\").value ORDER BY time) AS apparent_power,\r\n  LAST_VALUE((\"COSPHI\").value ORDER BY time)        AS cos_phi,\r\n  LAST_VALUE((\"POWERFACTOR\").value ORDER BY time)   AS power_factor,\r\n  LAST_VALUE((\"FREQUENCY\").value ORDER BY time)     AS frequency,\r\n  LAST_VALUE((\"NOZERO\").value ORDER BY time)        AS no_zero,\r\n  LAST_VALUE((\"VOLTAGESAG\").value ORDER BY time)    AS voltage_sag,\r\n  LAST_VALUE((\"4QUADRANT\").value ORDER BY time)     AS four_quadrant\r\nFROM marpower.\"450000_dynamic_conv_sb\"\r\nWHERE topic = 'marpower/450000-dynamic-conv-sb/ch1'\r\n",
+          "rawSql": "SELECT\r\n  timestamp               AS time,\r\n  current__value          AS current,\r\n  overcurrent__value      AS over_current,\r\n  voltage__value          AS voltage,\r\n  undervoltage__value     AS under_voltage,\r\n  overvoltage__value      AS over_voltage,\r\n  activepower__value      AS active_power,\r\n  reactivepower__value    AS reactive_power,\r\n  apparentpower__value    AS apparent_power,\r\n  cosphi__value           AS cos_phi,\r\n  powerfactor__value      AS power_factor,\r\n  frequency__value        AS frequency,\r\n  nozero__value           AS no_zero,\r\n  voltagesag__value       AS voltage_sag,\r\n  \"4_quadrant__value\"       AS four_quadrant\r\nFROM public.marpower__450000_dynamic_conv_sb\r\nWHERE topic = 'marpower/450000-dynamic-conv-sb/ch1'\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -20043,9 +20197,23 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"CURRENT\").value ORDER BY time)       AS current,\r\n  LAST_VALUE((\"OVERCURRENT\").value ORDER BY time)   AS over_current,\r\n  LAST_VALUE((\"VOLTAGE\").value ORDER BY time)       AS voltage,\r\n  LAST_VALUE((\"UNDERVOLTAGE\").value ORDER BY time)  AS under_voltage,\r\n  LAST_VALUE((\"OVERVOLTAGE\").value ORDER BY time)   AS over_voltage,\r\n  LAST_VALUE((\"ACTIVEPOWER\").value ORDER BY time)   AS active_power,\r\n  LAST_VALUE((\"REACTIVEPOWER\").value ORDER BY time) AS reactive_power,\r\n  LAST_VALUE((\"APPARENTPOWER\").value ORDER BY time) AS apparent_power,\r\n  LAST_VALUE((\"COSPHI\").value ORDER BY time)        AS cos_phi,\r\n  LAST_VALUE((\"POWERFACTOR\").value ORDER BY time)   AS power_factor,\r\n  LAST_VALUE((\"FREQUENCY\").value ORDER BY time)     AS frequency,\r\n  LAST_VALUE((\"NOZERO\").value ORDER BY time)        AS no_zero,\r\n  LAST_VALUE((\"VOLTAGESAG\").value ORDER BY time)    AS voltage_sag,\r\n  LAST_VALUE((\"4QUADRANT\").value ORDER BY time)     AS four_quadrant\r\nFROM marpower.\"450000_dynamic_conv_ps\"\r\nwhere topic = 'marpower/450000-dynamic-conv-ps/ch2'",
+          "rawSql": "SELECT\r\n  timestamp               AS time,\r\n  current__value          AS current,\r\n  overcurrent__value      AS over_current,\r\n  voltage__value          AS voltage,\r\n  undervoltage__value     AS under_voltage,\r\n  overvoltage__value      AS over_voltage,\r\n  activepower__value      AS active_power,\r\n  reactivepower__value    AS reactive_power,\r\n  apparentpower__value    AS apparent_power,\r\n  cosphi__value           AS cos_phi,\r\n  powerfactor__value      AS power_factor,\r\n  frequency__value        AS frequency,\r\n  nozero__value           AS no_zero,\r\n  voltagesag__value       AS voltage_sag,\r\n  \"4_quadrant__value\"       AS four_quadrant\r\nFROM public.marpower__450000_dynamic_conv_ps\r\nWHERE topic = 'marpower/450000-dynamic-conv-ps/ch2'\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -21254,9 +21422,23 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"CURRENT\").value ORDER BY time)       AS current,\r\n  LAST_VALUE((\"OVERCURRENT\").value ORDER BY time)   AS over_current,\r\n  LAST_VALUE((\"VOLTAGE\").value ORDER BY time)       AS voltage,\r\n  LAST_VALUE((\"UNDERVOLTAGE\").value ORDER BY time)  AS under_voltage,\r\n  LAST_VALUE((\"OVERVOLTAGE\").value ORDER BY time)   AS over_voltage,\r\n  LAST_VALUE((\"ACTIVEPOWER\").value ORDER BY time)   AS active_power,\r\n  LAST_VALUE((\"REACTIVEPOWER\").value ORDER BY time) AS reactive_power,\r\n  LAST_VALUE((\"APPARENTPOWER\").value ORDER BY time) AS apparent_power,\r\n  LAST_VALUE((\"COSPHI\").value ORDER BY time)        AS cos_phi,\r\n  LAST_VALUE((\"POWERFACTOR\").value ORDER BY time)   AS power_factor,\r\n  LAST_VALUE((\"FREQUENCY\").value ORDER BY time)     AS frequency,\r\n  LAST_VALUE((\"NOZERO\").value ORDER BY time)        AS no_zero,\r\n  LAST_VALUE((\"VOLTAGESAG\").value ORDER BY time)    AS voltage_sag,\r\n  LAST_VALUE((\"4QUADRANT\").value ORDER BY time)     AS four_quadrant\r\nFROM marpower.\"450000_dynamic_conv_sb\"\r\nWHERE topic = 'marpower/450000-dynamic-conv-sb/ch2'\r\n",
+          "rawSql": "SELECT\r\n  timestamp               AS time,\r\n  current__value          AS current,\r\n  overcurrent__value      AS over_current,\r\n  voltage__value          AS voltage,\r\n  undervoltage__value     AS under_voltage,\r\n  overvoltage__value      AS over_voltage,\r\n  activepower__value      AS active_power,\r\n  reactivepower__value    AS reactive_power,\r\n  apparentpower__value    AS apparent_power,\r\n  cosphi__value           AS cos_phi,\r\n  powerfactor__value      AS power_factor,\r\n  frequency__value        AS frequency,\r\n  nozero__value           AS no_zero,\r\n  voltagesag__value       AS voltage_sag,\r\n  \"4_quadrant__value\"       AS four_quadrant\r\nFROM public.marpower__450000_dynamic_conv_sb\r\nWHERE topic = 'marpower/450000-dynamic-conv-sb/ch2'\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -22465,9 +22647,23 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"CURRENT\").value ORDER BY time)       AS current,\r\n  LAST_VALUE((\"OVERCURRENT\").value ORDER BY time)   AS over_current,\r\n  LAST_VALUE((\"VOLTAGE\").value ORDER BY time)       AS voltage,\r\n  LAST_VALUE((\"UNDERVOLTAGE\").value ORDER BY time)  AS under_voltage,\r\n  LAST_VALUE((\"OVERVOLTAGE\").value ORDER BY time)   AS over_voltage,\r\n  LAST_VALUE((\"ACTIVEPOWER\").value ORDER BY time)   AS active_power,\r\n  LAST_VALUE((\"REACTIVEPOWER\").value ORDER BY time) AS reactive_power,\r\n  LAST_VALUE((\"APPARENTPOWER\").value ORDER BY time) AS apparent_power,\r\n  LAST_VALUE((\"COSPHI\").value ORDER BY time)        AS cos_phi,\r\n  LAST_VALUE((\"POWERFACTOR\").value ORDER BY time)   AS power_factor,\r\n  LAST_VALUE((\"FREQUENCY\").value ORDER BY time)     AS frequency,\r\n  LAST_VALUE((\"NOZERO\").value ORDER BY time)        AS no_zero,\r\n  LAST_VALUE((\"VOLTAGESAG\").value ORDER BY time)    AS voltage_sag,\r\n  LAST_VALUE((\"4QUADRANT\").value ORDER BY time)     AS four_quadrant\r\nFROM marpower.\"450000_dynamic_conv_ps\"\r\nwhere topic = 'marpower/450000-dynamic-conv-ps/ch3'",
+          "rawSql": "SELECT\r\n  timestamp               AS time,\r\n  current__value          AS current,\r\n  overcurrent__value      AS over_current,\r\n  voltage__value          AS voltage,\r\n  undervoltage__value     AS under_voltage,\r\n  overvoltage__value      AS over_voltage,\r\n  activepower__value      AS active_power,\r\n  reactivepower__value    AS reactive_power,\r\n  apparentpower__value    AS apparent_power,\r\n  cosphi__value           AS cos_phi,\r\n  powerfactor__value      AS power_factor,\r\n  frequency__value        AS frequency,\r\n  nozero__value           AS no_zero,\r\n  voltagesag__value       AS voltage_sag,\r\n  \"4_quadrant__value\"       AS four_quadrant\r\nFROM public.marpower__450000_dynamic_conv_ps\r\nWHERE topic = 'marpower/450000-dynamic-conv-ps/ch3'\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -23676,9 +23872,23 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"CURRENT\").value ORDER BY time)       AS current,\r\n  LAST_VALUE((\"OVERCURRENT\").value ORDER BY time)   AS over_current,\r\n  LAST_VALUE((\"VOLTAGE\").value ORDER BY time)       AS voltage,\r\n  LAST_VALUE((\"UNDERVOLTAGE\").value ORDER BY time)  AS under_voltage,\r\n  LAST_VALUE((\"OVERVOLTAGE\").value ORDER BY time)   AS over_voltage,\r\n  LAST_VALUE((\"ACTIVEPOWER\").value ORDER BY time)   AS active_power,\r\n  LAST_VALUE((\"REACTIVEPOWER\").value ORDER BY time) AS reactive_power,\r\n  LAST_VALUE((\"APPARENTPOWER\").value ORDER BY time) AS apparent_power,\r\n  LAST_VALUE((\"COSPHI\").value ORDER BY time)        AS cos_phi,\r\n  LAST_VALUE((\"POWERFACTOR\").value ORDER BY time)   AS power_factor,\r\n  LAST_VALUE((\"FREQUENCY\").value ORDER BY time)     AS frequency,\r\n  LAST_VALUE((\"NOZERO\").value ORDER BY time)        AS no_zero,\r\n  LAST_VALUE((\"VOLTAGESAG\").value ORDER BY time)    AS voltage_sag,\r\n  LAST_VALUE((\"4QUADRANT\").value ORDER BY time)     AS four_quadrant\r\nFROM marpower.\"450000_dynamic_conv_sb\"\r\nWHERE topic = 'marpower/450000-dynamic-conv-sb/ch3'\r\n",
+          "rawSql": "SELECT\r\n  timestamp               AS time,\r\n  current__value          AS current,\r\n  overcurrent__value      AS over_current,\r\n  voltage__value          AS voltage,\r\n  undervoltage__value     AS under_voltage,\r\n  overvoltage__value      AS over_voltage,\r\n  activepower__value      AS active_power,\r\n  reactivepower__value    AS reactive_power,\r\n  apparentpower__value    AS apparent_power,\r\n  cosphi__value           AS cos_phi,\r\n  powerfactor__value      AS power_factor,\r\n  frequency__value        AS frequency,\r\n  nozero__value           AS no_zero,\r\n  voltagesag__value       AS voltage_sag,\r\n  \"4_quadrant__value\"       AS four_quadrant\r\nFROM public.marpower__450000_dynamic_conv_sb\r\nWHERE topic = 'marpower/450000-dynamic-conv-sb/ch3'\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [

--- a/zero-dashboards/dashboards/Commissioning/pms-dashboard.json
+++ b/zero-dashboards/dashboards/Commissioning/pms-dashboard.json
@@ -2400,10 +2400,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"TEMPWARN1\").value ORDER BY time)        AS temp_warning_1,\r\n  LAST_VALUE((\"TEMPWARN2\").value ORDER BY time)        AS temp_warning_2,\r\n  LAST_VALUE((\"STATUSOK\").value ORDER BY time)         AS status_ok,\r\n  LAST_VALUE((\"ENABLEDISABLE\").value ORDER BY time)    AS control_enable,\r\n  LAST_VALUE((\"SAFETYDISCONNECT\").value ORDER BY time) AS control_safety_discon\r\nFROM marpower.\"450000_dc_distribution_conv\"\r\nWHERE topic = 'marpower/450000-dc-distribution/conv/keb7-sol1'",
+          "rawSql": "SELECT\r\n  timestamp                   AS time,\r\n  tempwarn_1__value           AS temp_warning_1,\r\n  tempwarn_2__value           AS temp_warning_2,\r\n  statusok__value             AS status_ok,\r\n  enabledisable__value        AS control_enable,\r\n  safetydisconnect__value     AS control_safety_discon\r\nFROM public.marpower__450000_dc_distribution__conv\r\nWHERE topic = 'marpower/450000-dc-distribution/conv/keb7_sol1'\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -2430,10 +2444,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"KEB7_SOL1_BEND_MPLUS\").value ORDER BY time) AS status_bend_mplus,\r\n  LAST_VALUE((\"KEB7_SOL1_BEND_Q\").value ORDER BY time)     AS status_bend_q,\r\n  LAST_VALUE((\"KEB7_SOL1_BENDI\").value ORDER BY time)      AS control_bend_i\r\nFROM marpower.\"450000_dc_distribution_general\"",
+          "rawSql": "SELECT\r\n  timestamp                     AS time,\r\n  keb_7_sol_1_bend_mplus__value AS status_bend_mplus,\r\n  keb_7_sol_1_bend_q__value     AS status_bend_q,\r\n  keb_7_sol_1_bendi__value      AS control_bend_i\r\nFROM public.marpower__450000_dc_distribution_general\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "B",
           "sql": {
             "columns": [
@@ -3605,10 +3633,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"TEMPWARN1\").value ORDER BY time)        AS conv1_temp_warning_1,\r\n  LAST_VALUE((\"TEMPWARN2\").value ORDER BY time)        AS conv1_temp_warning_2,\r\n  LAST_VALUE((\"STATUSOK\").value ORDER BY time)         AS status_conv1_ok,\r\n  LAST_VALUE((\"ENABLEDISABLE\").value ORDER BY time)    AS control_conv1_enable,\r\n  LAST_VALUE((\"SAFETYDISCONNECT\").value ORDER BY time) AS control_conv1_safety_discon\r\nFROM marpower.\"450000_dc_distribution_conv\"\r\nWHERE topic = 'marpower/450000-dc-distribution/conv/keb6-sol2-1'",
+          "rawSql": "SELECT\r\n  timestamp               AS time,\r\n  tempwarn_1__value       AS conv1_temp_warning_1,\r\n  tempwarn_2__value       AS conv1_temp_warning_2,\r\n  statusok__value         AS status_conv1_ok,\r\n  enabledisable__value    AS control_conv1_enable,\r\n  safetydisconnect__value AS control_conv1_safety_discon\r\nFROM public.marpower__450000_dc_distribution__conv\r\nWHERE topic = 'marpower/450000-dc-distribution/conv/keb6_sol2_1'\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -3635,10 +3677,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"TEMPWARN1\").value ORDER BY time)        AS conv2_temp_warning_1,\r\n  LAST_VALUE((\"TEMPWARN2\").value ORDER BY time)        AS conv2_temp_warning_2,\r\n  LAST_VALUE((\"STATUSOK\").value ORDER BY time)         AS status_conv2_ok,\r\n  LAST_VALUE((\"ENABLEDISABLE\").value ORDER BY time)    AS control_conv2_enable,\r\n  LAST_VALUE((\"SAFETYDISCONNECT\").value ORDER BY time) AS control_conv2_safety_discon\r\nFROM marpower.\"450000_dc_distribution_conv\"\r\nWHERE topic = 'marpower/450000-dc-distribution/conv/keb6-sol2-2'",
+          "rawSql": "SELECT\r\n  timestamp               AS time,\r\n  tempwarn_1__value       AS conv2_temp_warning_1,\r\n  tempwarn_2__value       AS conv2_temp_warning_2,\r\n  statusok__value         AS status_conv2_ok,\r\n  enabledisable__value    AS control_conv2_enable,\r\n  safetydisconnect__value AS control_conv2_safety_discon\r\nFROM public.marpower__450000_dc_distribution__conv\r\nWHERE topic = 'marpower/450000-dc-distribution/conv/keb6_sol2_2'\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "B",
           "sql": {
             "columns": [
@@ -3665,10 +3721,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"KEB6_SOL2_BENDMPLUS\").value ORDER BY time) AS status_bend_mplus,\r\n  LAST_VALUE((\"KEB6_SOL2_BENDQ\").value ORDER BY time)     AS status_bend_q,\r\n  LAST_VALUE((\"KEB6_SOL2_BENDI\").value ORDER BY time)     AS control_bend_i\r\nFROM marpower.\"450000_dc_distribution_general\"",
+          "rawSql": "SELECT\r\n  timestamp                    AS time,\r\n  keb_6_sol_2_bendmplus__value AS status_bend_mplus,\r\n  keb_6_sol_2_bendq__value     AS status_bend_q,\r\n  keb_6_sol_2_bendi__value     AS control_bend_i\r\nFROM public.marpower__450000_dc_distribution_general\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "C",
           "sql": {
             "columns": [

--- a/zero-dashboards/dashboards/Commissioning/pms-dashboard.json
+++ b/zero-dashboards/dashboards/Commissioning/pms-dashboard.json
@@ -4367,9 +4367,23 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"KEB6_BATT_CONV01_HVIL\").value ORDER BY time)     AS batt_conv_1,\r\n  LAST_VALUE((\"KEB6_BATT_CONV02_HVIL\").value ORDER BY time)     AS batt_conv_2,\r\n  LAST_VALUE((\"KEB7_BATT_CONV03_HVIL\").value ORDER BY time)     AS batt_conv_3,\r\n  LAST_VALUE((\"KEB7_BATT_CONV04_HVIL\").value ORDER BY time)     AS batt_conv_4,\r\n  LAST_VALUE((\"KEB8_BATT_CONV05_HVIL\").value ORDER BY time)     AS batt_conv_5,\r\n  LAST_VALUE((\"KEB9_BATT_CONV06_HVIL\").value ORDER BY time)     AS batt_conv_6\r\nFROM marpower.\"450000_dc_distribution_general\"",
+          "rawSql": "SELECT\r\n  timestamp                      AS time,\r\n  keb_6_batt_conv_01_hvil__value AS batt_conv_1,\r\n  keb_6_batt_conv_02_hvil__value AS batt_conv_2,\r\n  keb_7_batt_conv_03_hvil__value AS batt_conv_3,\r\n  keb_7_batt_conv_04_hvil__value AS batt_conv_4,\r\n  keb_8_batt_conv_05_hvil__value AS batt_conv_5,\r\n  keb_9_batt_conv_06_hvil__value AS batt_conv_6\r\nFROM public.marpower__450000_dc_distribution_general\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -5081,10 +5095,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"TRIPPED\").value ORDER BY time) AS tripped,\r\n  LAST_VALUE((\"OPENED\").value ORDER BY time)  AS status_opened,\r\n  LAST_VALUE((\"CLOSED\").value ORDER BY time)  AS status_closed,\r\n  LAST_VALUE((\"RUNNING\").value ORDER BY time) AS status_running,\r\n  LAST_VALUE((\"OPEN\").value ORDER BY time)    AS control_open,\r\n  LAST_VALUE((\"CLOSE\").value ORDER BY time)   AS control_close,\r\n  LAST_VALUE((\"RESET\").value ORDER BY time)   AS control_reset\r\nFROM marpower.\"450000_dc_distribution_dc_switch\"\r\nWHERE topic = 'marpower/450000-dc-distribution/dc-switch/keb6-0571'\r\n\r\n\r\n\r\n\r\n\r\n\r\n",
+          "rawSql": "SELECT\r\n  topic,\r\n  timestamp      AS time,\r\n  tripped__value AS tripped,\r\n  opened__value  AS status_opened,\r\n  closed__value  AS status_closed,\r\n  running__value AS status_running,\r\n  open__value    AS control_open,\r\n  close__value   AS control_close,\r\n  reset__value   AS control_reset\r\nFROM public.marpower__450000_dc_distribution__dc_switch__keb6_0571\r\nORDER BY timestamp DESC\r\nLIMIT 1\r\n",
           "refId": "A",
           "sql": {
             "columns": [
@@ -5783,10 +5811,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"TRIPPED\").value ORDER BY time) AS tripped,\r\n  LAST_VALUE((\"OPENED\").value ORDER BY time)  AS status_opened,\r\n  LAST_VALUE((\"CLOSED\").value ORDER BY time)  AS status_closed,\r\n  LAST_VALUE((\"RUNNING\").value ORDER BY time) AS status_running,\r\n  LAST_VALUE((\"OPEN\").value ORDER BY time)    AS control_open,\r\n  LAST_VALUE((\"CLOSE\").value ORDER BY time)   AS control_close,\r\n  LAST_VALUE((\"RESET\").value ORDER BY time)   AS control_reset\r\nFROM marpower.\"450000_dc_distribution_dc_switch\"\r\nWHERE topic = 'marpower/450000-dc-distribution/dc-switch/keb6-0572'\r\n\r\n\r\n\r\n\r\n\r\n\r\n",
+          "rawSql": "SELECT\r\n  topic,\r\n  timestamp      AS time,\r\n  tripped__value AS tripped,\r\n  opened__value  AS status_opened,\r\n  closed__value  AS status_closed,\r\n  running__value AS status_running,\r\n  open__value    AS control_open,\r\n  close__value   AS control_close,\r\n  reset__value   AS control_reset\r\nFROM public.marpower__450000_dc_distribution__dc_switch__keb6_0572\r\nORDER BY timestamp DESC\r\nLIMIT 1\r\n",
           "refId": "A",
           "sql": {
             "columns": [
@@ -6486,10 +6528,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"TRIPPED\").value ORDER BY time) AS tripped,\r\n  LAST_VALUE((\"OPENED\").value ORDER BY time)  AS status_opened,\r\n  LAST_VALUE((\"CLOSED\").value ORDER BY time)  AS status_closed,\r\n  LAST_VALUE((\"RUNNING\").value ORDER BY time) AS status_running,\r\n  LAST_VALUE((\"OPEN\").value ORDER BY time)    AS control_open,\r\n  LAST_VALUE((\"CLOSE\").value ORDER BY time)   AS control_close,\r\n  LAST_VALUE((\"RESET\").value ORDER BY time)   AS control_reset\r\nFROM marpower.\"450000_dc_distribution_dc_switch\"\r\nWHERE topic = 'marpower/450000-dc-distribution/dc-switch/keb6-0573'\r\n\r\n\r\n\r\n\r\n\r\n\r\n",
+          "rawSql": "SELECT\r\n  topic,\r\n  timestamp      AS time,\r\n  tripped__value AS tripped,\r\n  opened__value  AS status_opened,\r\n  closed__value  AS status_closed,\r\n  running__value AS status_running,\r\n  open__value    AS control_open,\r\n  close__value   AS control_close,\r\n  reset__value   AS control_reset\r\nFROM public.marpower__450000_dc_distribution__dc_switch__keb6_0573\r\nORDER BY timestamp DESC\r\nLIMIT 1\r\n",
           "refId": "A",
           "sql": {
             "columns": [
@@ -7189,10 +7245,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"TRIPPED\").value ORDER BY time) AS tripped,\r\n  LAST_VALUE((\"OPENED\").value ORDER BY time)  AS status_opened,\r\n  LAST_VALUE((\"CLOSED\").value ORDER BY time)  AS status_closed,\r\n  LAST_VALUE((\"RUNNING\").value ORDER BY time) AS status_running,\r\n  LAST_VALUE((\"OPEN\").value ORDER BY time)    AS control_open,\r\n  LAST_VALUE((\"CLOSE\").value ORDER BY time)   AS control_close,\r\n  LAST_VALUE((\"RESET\").value ORDER BY time)   AS control_reset\r\nFROM marpower.\"450000_dc_distribution_dc_switch\"\r\nWHERE topic = 'marpower/450000-dc-distribution/dc-switch/keb6-0574'\r\n\r\n\r\n\r\n\r\n\r\n\r\n",
+          "rawSql": "SELECT\r\n  topic,\r\n  timestamp      AS time,\r\n  tripped__value AS tripped,\r\n  opened__value  AS status_opened,\r\n  closed__value  AS status_closed,\r\n  running__value AS status_running,\r\n  open__value    AS control_open,\r\n  close__value   AS control_close,\r\n  reset__value   AS control_reset\r\nFROM public.marpower__450000_dc_distribution__dc_switch__keb6_0574\r\nORDER BY timestamp DESC\r\nLIMIT 1\r\n",
           "refId": "A",
           "sql": {
             "columns": [
@@ -7891,10 +7961,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"TRIPPED\").value ORDER BY time) AS tripped,\r\n  LAST_VALUE((\"OPENED\").value ORDER BY time)  AS status_opened,\r\n  LAST_VALUE((\"CLOSED\").value ORDER BY time)  AS status_closed,\r\n  LAST_VALUE((\"RUNNING\").value ORDER BY time) AS status_running,\r\n  LAST_VALUE((\"OPEN\").value ORDER BY time)    AS control_open,\r\n  LAST_VALUE((\"CLOSE\").value ORDER BY time)   AS control_close,\r\n  LAST_VALUE((\"RESET\").value ORDER BY time)   AS control_reset\r\nFROM marpower.\"450000_dc_distribution_dc_switch\"\r\nWHERE topic = 'marpower/450000-dc-distribution/dc-switch/keb7-0575'\r\n\r\n\r\n\r\n\r\n\r\n\r\n",
+          "rawSql": "SELECT\r\n  topic,\r\n  timestamp      AS time,\r\n  tripped__value AS tripped,\r\n  opened__value  AS status_opened,\r\n  closed__value  AS status_closed,\r\n  running__value AS status_running,\r\n  open__value    AS control_open,\r\n  close__value   AS control_close,\r\n  reset__value   AS control_reset\r\nFROM public.marpower__450000_dc_distribution__dc_switch__keb7_0575\r\nORDER BY timestamp DESC\r\nLIMIT 1\r\n",
           "refId": "A",
           "sql": {
             "columns": [
@@ -8593,10 +8677,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"TRIPPED\").value ORDER BY time) AS tripped,\r\n  LAST_VALUE((\"OPENED\").value ORDER BY time)  AS status_opened,\r\n  LAST_VALUE((\"CLOSED\").value ORDER BY time)  AS status_closed,\r\n  LAST_VALUE((\"RUNNING\").value ORDER BY time) AS status_running,\r\n  LAST_VALUE((\"OPEN\").value ORDER BY time)    AS control_open,\r\n  LAST_VALUE((\"CLOSE\").value ORDER BY time)   AS control_close,\r\n  LAST_VALUE((\"RESET\").value ORDER BY time)   AS control_reset\r\nFROM marpower.\"450000_dc_distribution_dc_switch\"\r\nWHERE topic = 'marpower/450000-dc-distribution/dc-switch/keb8-0576'\r\n\r\n\r\n\r\n\r\n\r\n\r\n",
+          "rawSql": "SELECT\r\n  topic,\r\n  timestamp      AS time,\r\n  tripped__value AS tripped,\r\n  opened__value  AS status_opened,\r\n  closed__value  AS status_closed,\r\n  running__value AS status_running,\r\n  open__value    AS control_open,\r\n  close__value   AS control_close,\r\n  reset__value   AS control_reset\r\nFROM public.marpower__450000_dc_distribution__dc_switch__keb8_0576\r\nORDER BY timestamp DESC\r\nLIMIT 1\r\n",
           "refId": "A",
           "sql": {
             "columns": [
@@ -9295,10 +9393,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"TRIPPED\").value ORDER BY time) AS tripped,\r\n  LAST_VALUE((\"OPENED\").value ORDER BY time)  AS status_opened,\r\n  LAST_VALUE((\"CLOSED\").value ORDER BY time)  AS status_closed,\r\n  LAST_VALUE((\"RUNNING\").value ORDER BY time) AS status_running,\r\n  LAST_VALUE((\"OPEN\").value ORDER BY time)    AS control_open,\r\n  LAST_VALUE((\"CLOSE\").value ORDER BY time)   AS control_close,\r\n  LAST_VALUE((\"RESET\").value ORDER BY time)   AS control_reset\r\nFROM marpower.\"450000_dc_distribution_dc_switch\"\r\nWHERE topic = 'marpower/450000-dc-distribution/dc-switch/keb8-0577'\r\n\r\n\r\n\r\n\r\n\r\n\r\n",
+          "rawSql": "SELECT\r\n  topic,\r\n  timestamp      AS time,\r\n  tripped__value AS tripped,\r\n  opened__value  AS status_opened,\r\n  closed__value  AS status_closed,\r\n  running__value AS status_running,\r\n  open__value    AS control_open,\r\n  close__value   AS control_close,\r\n  reset__value   AS control_reset\r\nFROM public.marpower__450000_dc_distribution__dc_switch__keb8_0577\r\nORDER BY timestamp DESC\r\nLIMIT 1\r\n",
           "refId": "A",
           "sql": {
             "columns": [
@@ -9997,10 +10109,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"TRIPPED\").value ORDER BY time) AS tripped,\r\n  LAST_VALUE((\"OPENED\").value ORDER BY time)  AS status_opened,\r\n  LAST_VALUE((\"CLOSED\").value ORDER BY time)  AS status_closed,\r\n  LAST_VALUE((\"RUNNING\").value ORDER BY time) AS status_running,\r\n  LAST_VALUE((\"OPEN\").value ORDER BY time)    AS control_open,\r\n  LAST_VALUE((\"CLOSE\").value ORDER BY time)   AS control_close,\r\n  LAST_VALUE((\"RESET\").value ORDER BY time)   AS control_reset\r\nFROM marpower.\"450000_dc_distribution_dc_switch\"\r\nWHERE topic = 'marpower/450000-dc-distribution/dc-switch/keb9-0578'\r\n\r\n\r\n\r\n\r\n\r\n\r\n",
+          "rawSql": "SELECT\r\n  topic,\r\n  timestamp      AS time,\r\n  tripped__value AS tripped,\r\n  opened__value  AS status_opened,\r\n  closed__value  AS status_closed,\r\n  running__value AS status_running,\r\n  open__value    AS control_open,\r\n  close__value   AS control_close,\r\n  reset__value   AS control_reset\r\nFROM public.marpower__450000_dc_distribution__dc_switch__keb9_0578\r\nORDER BY timestamp DESC\r\nLIMIT 1\r\n",
           "refId": "A",
           "sql": {
             "columns": [
@@ -10693,10 +10819,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"TRIPPED\").value ORDER BY time) AS tripped,\r\n  LAST_VALUE((\"OPENED\").value ORDER BY time)  AS status_opened,\r\n  LAST_VALUE((\"CLOSED\").value ORDER BY time)  AS status_closed,\r\n  LAST_VALUE((\"RUNNING\").value ORDER BY time) AS status_running,\r\n  LAST_VALUE((\"OPEN\").value ORDER BY time)    AS control_open,\r\n  LAST_VALUE((\"CLOSE\").value ORDER BY time)   AS control_close,\r\n  LAST_VALUE((\"RESET\").value ORDER BY time)   AS control_reset\r\nFROM marpower.\"450000_dc_distribution_dc_switch\"\r\nWHERE topic = 'marpower/450000-dc-distribution/dc-switch/keb7-0573'\r\n\r\n\r\n\r\n\r\n\r\n\r\n",
+          "rawSql": "SELECT\r\n  topic,\r\n  timestamp      AS time,\r\n  tripped__value AS tripped,\r\n  opened__value  AS status_opened,\r\n  closed__value  AS status_closed,\r\n  running__value AS status_running,\r\n  open__value    AS control_open,\r\n  close__value   AS control_close,\r\n  reset__value   AS control_reset\r\nFROM public.marpower__450000_dc_distribution__dc_switch__keb7_0573\r\nORDER BY timestamp DESC\r\nLIMIT 1\r\n",
           "refId": "A",
           "sql": {
             "columns": [
@@ -11389,10 +11529,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"TRIPPED\").value ORDER BY time) AS tripped,\r\n  LAST_VALUE((\"OPENED\").value ORDER BY time)  AS status_opened,\r\n  LAST_VALUE((\"CLOSED\").value ORDER BY time)  AS status_closed,\r\n  LAST_VALUE((\"RUNNING\").value ORDER BY time) AS status_running,\r\n  LAST_VALUE((\"OPEN\").value ORDER BY time)    AS control_open,\r\n  LAST_VALUE((\"CLOSE\").value ORDER BY time)   AS control_close,\r\n  LAST_VALUE((\"RESET\").value ORDER BY time)   AS control_reset\r\nFROM marpower.\"450000_dc_distribution_dc_switch\"\r\nWHERE topic = 'marpower/450000-dc-distribution/dc-switch/keb7-0574'\r\n\r\n\r\n\r\n\r\n\r\n\r\n",
+          "rawSql": "SELECT\r\n  topic,\r\n  timestamp      AS time,\r\n  tripped__value AS tripped,\r\n  opened__value  AS status_opened,\r\n  closed__value  AS status_closed,\r\n  running__value AS status_running,\r\n  open__value    AS control_open,\r\n  close__value   AS control_close,\r\n  reset__value   AS control_reset\r\nFROM public.marpower__450000_dc_distribution__dc_switch__keb7_0574\r\nORDER BY timestamp DESC\r\nLIMIT 1\r\n",
           "refId": "A",
           "sql": {
             "columns": [

--- a/zero-dashboards/dashboards/Commissioning/pms-dashboard.json
+++ b/zero-dashboards/dashboards/Commissioning/pms-dashboard.json
@@ -27622,10 +27622,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"ISOLATIONWARNING\").value ORDER BY time)          AS isolation_warning,\r\n  LAST_VALUE((\"ISOLATIONFAULT\").value ORDER BY time)            AS isolation_fault,\r\n  LAST_VALUE((\"AUXPOWER700TO24VDCFAILURE\").value ORDER BY time) AS failure_700_24v,\r\n  LAST_VALUE((\"AUXPOWER24TO24VDCFAILURE\").value ORDER BY time)  AS failure_24v,\r\n  LAST_VALUE((\"BUSVOLTPRESENT\").value ORDER BY time)            AS status_bus_volt_present,\r\n  LAST_VALUE((\"OPERATINGVOLTPRESENT\").value ORDER BY time)      AS status_operating_volt_present,\r\n  LAST_VALUE((\"ISOLATIONDISABLED\").value ORDER BY time)         AS status_isolation_disabled,\r\n  LAST_VALUE((\"DISABLEISOLATION\").value ORDER BY time)          AS control_disable_isolation\r\nFROM marpower.\"450000_dc_distribution_350v_conv\"\r\nWHERE topic = 'marpower/450000-dc-distribution/350v-conv/keb7'",
+          "rawSql": "SELECT\r\n  timestamp                            AS time,\r\n  isolationwarning__value              AS isolation_warning,\r\n  isolationfault__value                AS isolation_fault,\r\n  auxpower_700_to_24_vdcfailure__value AS failure_700_24v,\r\n  auxpower_24_to_24_vdcfailure__value  AS failure_24v,\r\n  busvoltpresent__value                AS status_bus_volt_present,\r\n  operatingvoltpresent__value          AS status_operating_volt_present,\r\n  isolationdisabled__value             AS status_isolation_disabled,\r\n  disableisolation__value              AS control_disable_isolation\r\nFROM public.marpower__450000_dc_distribution__350v_conv__keb7\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -28399,10 +28413,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"ISOLATIONWARNING\").value ORDER BY time)          AS isolation_warning,\r\n  LAST_VALUE((\"ISOLATIONFAULT\").value ORDER BY time)            AS isolation_fault,\r\n  LAST_VALUE((\"AUXPOWER700TO24VDCFAILURE\").value ORDER BY time) AS failure_700_24v,\r\n  LAST_VALUE((\"AUXPOWER24TO24VDCFAILURE\").value ORDER BY time)  AS failure_24v,\r\n  LAST_VALUE((\"BUSVOLTPRESENT\").value ORDER BY time)            AS status_bus_volt_present,\r\n  LAST_VALUE((\"OPERATINGVOLTPRESENT\").value ORDER BY time)      AS status_operating_volt_present,\r\n  LAST_VALUE((\"ISOLATIONDISABLED\").value ORDER BY time)         AS status_isolation_disabled,\r\n  LAST_VALUE((\"DISABLEISOLATION\").value ORDER BY time)          AS control_disable_isolation\r\nFROM marpower.\"450000_dc_distribution_350v_conv\"\r\nWHERE topic = 'marpower/450000-dc-distribution/350v-conv/keb8'",
+          "rawSql": "SELECT\r\n  timestamp                            AS time,\r\n  isolationwarning__value              AS isolation_warning,\r\n  isolationfault__value                AS isolation_fault,\r\n  auxpower_700_to_24_vdcfailure__value AS failure_700_24v,\r\n  auxpower_24_to_24_vdcfailure__value  AS failure_24v,\r\n  busvoltpresent__value                AS status_bus_volt_present,\r\n  operatingvoltpresent__value          AS status_operating_volt_present,\r\n  isolationdisabled__value             AS status_isolation_disabled,\r\n  disableisolation__value              AS control_disable_isolation\r\nFROM public.marpower__450000_dc_distribution__350v_conv__keb8\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -28854,10 +28882,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"KEB7_LDC01_ISOLATIONWARNING\").value ORDER BY time)  AS isolation_warning,\r\n  LAST_VALUE((\"KEB7_LDC01_ISOLATIONFAULT\").value ORDER BY time)    AS isolation_fault,\r\n  LAST_VALUE((\"KEB7_LDC01_ISOLATIONDISABLED\").value ORDER BY time) AS status_isolation_disabled,\r\n  LAST_VALUE((\"KEB7_LDC01_ISOLATIONDISABLE\").value ORDER BY time)  AS control_disable_isolation\r\nFROM marpower.\"450000_dc_distribution_general\"\r\n",
+          "rawSql": "SELECT\r\n  timestamp                                    AS time,\r\n  keb_7_ldc_01_isolationwarning__value         AS isolation_warning,\r\n  keb_7_ldc_01_isolationfault__value           AS isolation_fault,\r\n  keb_7_ldc_01_isolationdisabled__value        AS status_isolation_disabled,\r\n  keb_7_ldc_01_isolationdisable__value         AS control_disable_isolation\r\nFROM public.marpower__450000_dc_distribution_general\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -29309,10 +29351,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"KEB9_LDC02_ISOLATIONWARNING\").value ORDER BY time)  AS isolation_warning,\r\n  LAST_VALUE((\"KEB9_LDC02_ISOLATIONFAULT\").value ORDER BY time)    AS isolation_fault,\r\n  LAST_VALUE((\"KEB9_LDC02_ISOLATIONDISABLED\").value ORDER BY time) AS status_isolation_disabled,\r\n  LAST_VALUE((\"KEB9_LDC01_ISOLATIONDISABLE\").value ORDER BY time)  AS control_disable_isolation\r\nFROM marpower.\"450000_dc_distribution_general\"\r\n",
+          "rawSql": "SELECT\r\n  timestamp                                    AS time,\r\n  keb_9_ldc_02_isolationwarning__value         AS isolation_warning,\r\n  keb_9_ldc_02_isolationfault__value           AS isolation_fault,\r\n  keb_9_ldc_02_isolationdisabled__value        AS status_isolation_disabled,\r\n  keb_9_ldc_01_isolationdisable__value         AS control_disable_isolation\r\nFROM public.marpower__450000_dc_distribution_general\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -29850,10 +29906,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"TEMPWARN1\").value ORDER BY time)        AS temp_warning1,\r\n  LAST_VALUE((\"TEMPWARN2\").value ORDER BY time)        AS temp_warning2,\r\n  LAST_VALUE((\"STATUSOK\").value ORDER BY time)         AS status_ok,\r\n  LAST_VALUE((\"ENABLEDISABLE\").value ORDER BY time)    AS control_enable,\r\n  LAST_VALUE((\"SAFETYDISCONNECT\").value ORDER BY time) AS control_safety_disconnect\r\nFROM marpower.\"450000_dc_distribution_conv\"\r\nWHERE topic = 'marpower/450000-dc-distribution/conv/keb7-ldc1-1'",
+          "rawSql": "SELECT\r\n  timestamp               AS time,\r\n  tempwarn_1__value       AS temp_warning1,\r\n  tempwarn_2__value       AS temp_warning2,\r\n  statusok__value         AS status_ok,\r\n  enabledisable__value    AS control_enable,\r\n  safetydisconnect__value AS control_safety_disconnect\r\nFROM public.marpower__450000_dc_distribution__conv\r\nWHERE topic = 'marpower/450000-dc-distribution/conv/keb7_ldc1_1'\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -30391,10 +30461,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"TEMPWARN1\").value ORDER BY time)        AS temp_warning1,\r\n  LAST_VALUE((\"TEMPWARN2\").value ORDER BY time)        AS temp_warning2,\r\n  LAST_VALUE((\"STATUSOK\").value ORDER BY time)         AS status_ok,\r\n  LAST_VALUE((\"ENABLEDISABLE\").value ORDER BY time)    AS control_enable,\r\n  LAST_VALUE((\"SAFETYDISCONNECT\").value ORDER BY time) AS control_safety_disconnect\r\nFROM marpower.\"450000_dc_distribution_conv\"\r\nWHERE topic = 'marpower/450000-dc-distribution/conv/keb7-ldc1-2'",
+          "rawSql": "SELECT\r\n  timestamp               AS time,\r\n  tempwarn_1__value       AS temp_warning1,\r\n  tempwarn_2__value       AS temp_warning2,\r\n  statusok__value         AS status_ok,\r\n  enabledisable__value    AS control_enable,\r\n  safetydisconnect__value AS control_safety_disconnect\r\nFROM public.marpower__450000_dc_distribution__conv\r\nWHERE topic = 'marpower/450000-dc-distribution/conv/keb7_ldc1_2'\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -30932,10 +31016,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"TEMPWARN1\").value ORDER BY time)        AS temp_warning1,\r\n  LAST_VALUE((\"TEMPWARN2\").value ORDER BY time)        AS temp_warning2,\r\n  LAST_VALUE((\"STATUSOK\").value ORDER BY time)         AS status_ok,\r\n  LAST_VALUE((\"ENABLEDISABLE\").value ORDER BY time)    AS control_enable,\r\n  LAST_VALUE((\"SAFETYDISCONNECT\").value ORDER BY time) AS control_safety_disconnect\r\nFROM marpower.\"450000_dc_distribution_conv\"\r\nWHERE topic = 'marpower/450000-dc-distribution/conv/keb9-ldc2-1'",
+          "rawSql": "SELECT\r\n  timestamp               AS time,\r\n  tempwarn_1__value       AS temp_warning1,\r\n  tempwarn_2__value       AS temp_warning2,\r\n  statusok__value         AS status_ok,\r\n  enabledisable__value    AS control_enable,\r\n  safetydisconnect__value AS control_safety_disconnect\r\nFROM public.marpower__450000_dc_distribution__conv\r\nWHERE topic = 'marpower/450000-dc-distribution/conv/keb9_ldc2_1'\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -31473,10 +31571,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"TEMPWARN1\").value ORDER BY time)        AS temp_warning1,\r\n  LAST_VALUE((\"TEMPWARN2\").value ORDER BY time)        AS temp_warning2,\r\n  LAST_VALUE((\"STATUSOK\").value ORDER BY time)         AS status_ok,\r\n  LAST_VALUE((\"ENABLEDISABLE\").value ORDER BY time)    AS control_enable,\r\n  LAST_VALUE((\"SAFETYDISCONNECT\").value ORDER BY time) AS control_safety_disconnect\r\nFROM marpower.\"450000_dc_distribution_conv\"\r\nWHERE topic = 'marpower/450000-dc-distribution/conv/keb9-ldc2-2'",
+          "rawSql": "SELECT\r\n  timestamp               AS time,\r\n  tempwarn_1__value       AS temp_warning1,\r\n  tempwarn_2__value       AS temp_warning2,\r\n  statusok__value         AS status_ok,\r\n  enabledisable__value    AS control_enable,\r\n  safetydisconnect__value AS control_safety_disconnect\r\nFROM public.marpower__450000_dc_distribution__conv\r\nWHERE topic = 'marpower/450000-dc-distribution/conv/keb9_ldc2_2'\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [

--- a/zero-dashboards/dashboards/Commissioning/pms-dashboard.json
+++ b/zero-dashboards/dashboards/Commissioning/pms-dashboard.json
@@ -18,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 0,
+  "id": 13,
   "links": [
     {
       "asDropdown": true,
@@ -77,8 +77,8 @@
     },
     {
       "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "${datasource}"
+        "type": "info8fcc-greptimedb-datasource",
+        "uid": "PBAD09CF7391C3C43"
       },
       "fieldConfig": {
         "defaults": {
@@ -815,10 +815,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"KEB6_AFT_THRUST_MAIN_BREAK_OF1_F105_FAULT\").value ORDER BY time) AS f105_fault,\r\n  LAST_VALUE((\"KEB6_AFT_THRUST_MAINBREAKOF1F105OPENCMD\").value ORDER BY time)   AS control_f105_open,\r\n  LAST_VALUE((\"KEB6_AFT_THRUST_MAIN_BREAK_OF1_F105_OPEN\").value ORDER BY time)  AS status_f105_open1,\r\n  LAST_VALUE((\"KEB6_AFT_THRUST_MAIN_BREAK_OF2_F105_OPEN\").value ORDER BY time)  AS status_f105_open2,\r\n  LAST_VALUE((\"KEB7_AFT_THRUST_MAINBREAKOF1F110FAULT\").value ORDER BY time)     AS f110_fault,\r\n  LAST_VALUE((\"KEB7_AFT_THRUST_MAINBREAKOF1F110OPENCMD\").value ORDER BY time)   AS control_f110_open,\r\n  LAST_VALUE((\"KEB7_AFT_THRUST_MAINBREAKOF1F110OPEN\").value ORDER BY time)      AS status_f110_open1,\r\n  LAST_VALUE((\"KEB7_AFT_THRUST_MAINBREAKOF2F110OPEN\").value ORDER BY time)      AS status_f110_open2\r\nFROM marpower.\"450000_dc_distribution_general\"\r\n\r\n\r\n\r\n\r\n\r\n\r\n",
+          "rawSql": "SELECT\r\n  timestamp                                           AS time,\r\n  keb_6_aft_thrust_main_break_of_1_f_105_fault__value AS f105_fault,\r\n  keb_6_aft_thrust_mainbreakof_1_f_105_opencmd__value AS control_f105_open,\r\n  keb_6_aft_thrust_main_break_of_1_f_105_open__value  AS status_f105_open1,\r\n  keb_6_aft_thrust_main_break_of_2_f_105_open__value  AS status_f105_open2,\r\n  keb_7_aft_thrust_mainbreakof_1_f_110_fault__value   AS f110_fault,\r\n  keb_7_aft_thrust_mainbreakof_1_f_110_opencmd__value AS control_f110_open,\r\n  keb_7_aft_thrust_mainbreakof_1_f_110_open__value    AS status_f110_open1,\r\n  keb_7_aft_thrust_mainbreakof_2_f_110_open__value    AS status_f110_open2\r\nFROM public.marpower__450000_dc_distribution_general\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -1582,10 +1596,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"KEB8_BOW_THRUST_MAINBREAKOF1F105FAULT\").value ORDER BY time)   AS f105_fault,\r\n  LAST_VALUE((\"KEB8_BOW_THRUST_MAINBREAKOF1F105OPENCMD\").value ORDER BY time) AS control_f105_open,\r\n  LAST_VALUE((\"KEB8_BOW_THRUST_MAINBREAKOF1F105OPEN\").value ORDER BY time)    AS status_f105_open1,\r\n  LAST_VALUE((\"KEB8_BOW_THRUST_MAINBREAKOF2F105OPEN\").value ORDER BY time)    AS status_f105_open2,\r\n  LAST_VALUE((\"KEB9_BOW_THRUST_MAINBREAKOF1F110FAULT\").value ORDER BY time)   AS f110_fault,\r\n  LAST_VALUE((\"KEB9_BOW_THRUST_MAINBREAKOF1F110OPENCMD\").value ORDER BY time) AS control_f110_open,\r\n  LAST_VALUE((\"KEB9_BOW_THRUST_MAINBREAKOF1F110OPEN\").value ORDER BY time)    AS status_f110_open1,\r\n  LAST_VALUE((\"KEB9_BOW_THRUST_MAINBREAKOF2F110OPEN\").value ORDER BY time)    AS status_f110_open2\r\nFROM marpower.\"450000_dc_distribution_general\"\r\n\r\n\r\n\r\n\r\n\r\n\r\n",
+          "rawSql": "SELECT\r\n  timestamp                                           AS time,\r\n  keb_8_bow_thrust_mainbreakof_1_f_105_fault__value   AS f105_fault,\r\n  keb_8_bow_thrust_mainbreakof_1_f_105_opencmd__value AS control_f105_open,\r\n  keb_8_bow_thrust_mainbreakof_1_f_105_open__value    AS status_f105_open1,\r\n  keb_8_bow_thrust_mainbreakof_2_f_105_open__value    AS status_f105_open2,\r\n  keb_9_bow_thrust_mainbreakof_1_f_110_fault__value   AS f110_fault,\r\n  keb_9_bow_thrust_mainbreakof_1_f_110_opencmd__value AS control_f110_open,\r\n  keb_9_bow_thrust_mainbreakof_1_f_110_open__value    AS status_f110_open1,\r\n  keb_9_bow_thrust_mainbreakof_2_f_110_open__value    AS status_f110_open2\r\nFROM public.marpower__450000_dc_distribution_general\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -36648,12 +36676,12 @@
     "list": [
       {
         "current": {
-          "text": "RisingWave",
-          "value": "ceyj3m7wtn3swb"
+          "text": "greptimedb-singel",
+          "value": "PE746E5A5E0A52672"
         },
         "name": "datasource",
         "options": [],
-        "query": "grafana-postgresql-datasource",
+        "query": "info8fcc-greptimedb-datasource",
         "refresh": 1,
         "regex": "",
         "type": "datasource"

--- a/zero-dashboards/dashboards/Commissioning/pms-dashboard.json
+++ b/zero-dashboards/dashboards/Commissioning/pms-dashboard.json
@@ -24786,7 +24786,7 @@
           "pluginVersion": "2.1.4",
           "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  timestamp             AS time,\r\n  ugrid_aft_digout_1__value       AS digital_output1,\r\n  ugrid_aft_digout_2__value       AS digital_output2\r\nFROM public.marpower__450000_ugrid\r\nORDER BY timestamp DESC\r\nLIMIT 1",
+          "rawSql": "SELECT\r\n  timestamp             AS time,\r\n  ugrid_aft_enable__value         AS enable,\r\n  ugrid_aft_enablefirmware__value AS enable_firmware_update,\r\n  ugrid_aft_digout_1__value       AS digital_output1,\r\n  ugrid_aft_digout_2__value       AS digital_output2\r\nFROM public.marpower__450000_ugrid\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -25227,7 +25227,7 @@
           "pluginVersion": "2.1.4",
           "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  timestamp             AS time,\r\n  ugrid_fwd_digout_1__value       AS digital_output1,\r\n  ugrid_fwd_digout_2__value       AS digital_output2\r\nFROM public.marpower__450000_ugrid\r\nORDER BY timestamp DESC\r\nLIMIT 1",
+          "rawSql": "SELECT\r\n  timestamp             AS time,\r\n  ugrid_fwd_enable__value         AS enable,\r\n  ugrid_fwd_enablefirmware__value AS enable_firmware_update,\r\n  ugrid_fwd_digout_1__value       AS digital_output1,\r\n  ugrid_fwd_digout_2__value       AS digital_output2\r\nFROM public.marpower__450000_ugrid\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -35873,7 +35873,7 @@
                 "size": 16,
                 "text": {
                   "field": "sub_pump1_alarm",
-                  "fixed": "Emergency switch PTU 1 - Off",
+                  "fixed": "Emergency switch - Off",
                   "mode": "fixed"
                 },
                 "valign": "middle"
@@ -35890,87 +35890,6 @@
                 "rotation": 0,
                 "top": 85,
                 "width": 241.23333740234375
-              },
-              "type": "text"
-            },
-            {
-              "background": {
-                "color": {
-                  "field": "control_em_switch2_off",
-                  "fixed": "#D9D9D9"
-                },
-                "image": {
-                  "field": "sub_pump1_alarm",
-                  "mode": "fixed"
-                }
-              },
-              "border": {
-                "color": {
-                  "fixed": "dark-green"
-                }
-              },
-              "config": {
-                "align": "center",
-                "color": {
-                  "fixed": "#000000"
-                },
-                "text": {
-                  "field": "sub_pump2_alarm",
-                  "mode": "fixed"
-                },
-                "valign": "middle"
-              },
-              "constraint": {
-                "horizontal": "left",
-                "vertical": "top"
-              },
-              "links": [],
-              "name": "control_em_switch2_off",
-              "placement": {
-                "height": 25,
-                "left": 15,
-                "rotation": 0,
-                "top": 115,
-                "width": 25
-              },
-              "type": "ellipse"
-            },
-            {
-              "background": {
-                "color": {
-                  "fixed": "transparent"
-                }
-              },
-              "border": {
-                "color": {
-                  "fixed": "dark-green"
-                }
-              },
-              "config": {
-                "align": "left",
-                "color": {
-                  "fixed": "rgb(204, 204, 220)"
-                },
-                "size": 16,
-                "text": {
-                  "field": "sub_pump1_alarm",
-                  "fixed": "Emergency switch PTU 2 - Off",
-                  "mode": "fixed"
-                },
-                "valign": "middle"
-              },
-              "constraint": {
-                "horizontal": "left",
-                "vertical": "top"
-              },
-              "links": [],
-              "name": "control_em_switch2_off label",
-              "placement": {
-                "height": 26,
-                "left": 50,
-                "rotation": 0,
-                "top": 115,
-                "width": 241
               },
               "type": "text"
             }
@@ -36018,52 +35937,8 @@
           "pluginVersion": "2.1.4",
           "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  timestamp          AS time,\r\n  error__value       AS error,\r\n  overload__value    AS overload,\r\n  online__value      AS status_online,\r\n  available__value   AS status_available\r\nFROM public.marpower__450000_dc_distribution__esi\r\nWHERE topic = 'marpower/450000-dc-distribution/esi/keb6'\r\nORDER BY timestamp DESC\r\nLIMIT 1",
+          "rawSql": "SELECT\r\n  timestamp             AS time,\r\n  error__value          AS error,\r\n  overload__value       AS overload,\r\n  online__value         AS status_online,\r\n  available__value      AS status_available,\r\n  emergswitchoff__value AS control_em_switch1_off\r\nFROM public.marpower__450000_dc_distribution__esi\r\nWHERE topic = 'marpower/450000-dc-distribution/esi/keb6'\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
-          "sql": {
-            "columns": [
-              {
-                "parameters": [],
-                "type": "function"
-              }
-            ],
-            "groupBy": [
-              {
-                "property": {
-                  "type": "string"
-                },
-                "type": "groupBy"
-              }
-            ],
-            "limit": 50
-          }
-        },
-        {
-          "dataset": "dev",
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "editorType": "sql",
-          "format": 1,
-          "hide": false,
-          "meta": {
-            "builderOptions": {
-              "columns": [],
-              "database": "",
-              "limit": 1000,
-              "meta": {},
-              "mode": "list",
-              "queryType": "table",
-              "table": ""
-            }
-          },
-          "pluginVersion": "2.1.4",
-          "queryType": "table",
-          "rawQuery": true,
-          "rawSql": "SELECT\r\n  timestamp                                     AS time,\r\n  NULL AS control_em_switch1_off,\r\n  NULL AS control_em_switch2_off\r\nFROM public.marpower__450000_dc_distribution_general\r\nORDER BY timestamp DESC\r\nLIMIT 1",
-          "refId": "B",
           "sql": {
             "columns": [
               {
@@ -36547,7 +36422,7 @@
                 "size": 16,
                 "text": {
                   "field": "sub_pump1_alarm",
-                  "fixed": "Emergency switch PTU 3 - Off",
+                  "fixed": "Emergency switch - Off",
                   "mode": "fixed"
                 },
                 "valign": "middle"
@@ -36564,87 +36439,6 @@
                 "rotation": 0,
                 "top": 85,
                 "width": 241.23333740234375
-              },
-              "type": "text"
-            },
-            {
-              "background": {
-                "color": {
-                  "field": "control_em_switch2_off",
-                  "fixed": "#D9D9D9"
-                },
-                "image": {
-                  "field": "sub_pump1_alarm",
-                  "mode": "fixed"
-                }
-              },
-              "border": {
-                "color": {
-                  "fixed": "dark-green"
-                }
-              },
-              "config": {
-                "align": "center",
-                "color": {
-                  "fixed": "#000000"
-                },
-                "text": {
-                  "field": "sub_pump2_alarm",
-                  "mode": "fixed"
-                },
-                "valign": "middle"
-              },
-              "constraint": {
-                "horizontal": "left",
-                "vertical": "top"
-              },
-              "links": [],
-              "name": "control_em_switch2_off",
-              "placement": {
-                "height": 25,
-                "left": 15,
-                "rotation": 0,
-                "top": 115,
-                "width": 25
-              },
-              "type": "ellipse"
-            },
-            {
-              "background": {
-                "color": {
-                  "fixed": "transparent"
-                }
-              },
-              "border": {
-                "color": {
-                  "fixed": "dark-green"
-                }
-              },
-              "config": {
-                "align": "left",
-                "color": {
-                  "fixed": "rgb(204, 204, 220)"
-                },
-                "size": 16,
-                "text": {
-                  "field": "sub_pump1_alarm",
-                  "fixed": "Emergency switch PTU 4 - Off",
-                  "mode": "fixed"
-                },
-                "valign": "middle"
-              },
-              "constraint": {
-                "horizontal": "left",
-                "vertical": "top"
-              },
-              "links": [],
-              "name": "control_em_switch2_off label",
-              "placement": {
-                "height": 26,
-                "left": 50,
-                "rotation": 0,
-                "top": 115,
-                "width": 241
               },
               "type": "text"
             }
@@ -36692,38 +36486,8 @@
           "pluginVersion": "2.1.4",
           "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  timestamp          AS time,\r\n  error__value       AS error,\r\n  overload__value    AS overload,\r\n  online__value      AS status_online,\r\n  available__value   AS status_available\r\nFROM public.marpower__450000_dc_distribution__esi\r\nWHERE topic = 'marpower/450000-dc-distribution/esi/keb7'\r\nORDER BY timestamp DESC\r\nLIMIT 1",
+          "rawSql": "SELECT\r\n  timestamp             AS time,\r\n  error__value          AS error,\r\n  overload__value       AS overload,\r\n  online__value         AS status_online,\r\n  available__value      AS status_available,\r\n  emergswitchoff__value AS control_em_switch1_off\r\nFROM public.marpower__450000_dc_distribution__esi\r\nWHERE topic = 'marpower/450000-dc-distribution/esi/keb7'\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
-          "sql": {
-            "columns": [
-              {
-                "parameters": [],
-                "type": "function"
-              }
-            ],
-            "groupBy": [
-              {
-                "property": {
-                  "type": "string"
-                },
-                "type": "groupBy"
-              }
-            ],
-            "limit": 50
-          }
-        },
-        {
-          "dataset": "dev",
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "format": "table",
-          "hide": false,
-          "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"KEB7_ESI_SB_EMERGSWITCHOFF3\").value ORDER BY time) AS control_em_switch1_off,\r\n  LAST_VALUE((\"KEB7_ESI_SB_EMERGSWITCHOFF4\").value ORDER BY time) AS control_em_switch2_off\r\nFROM marpower.\"450000_dc_distribution_general\"",
-          "refId": "B",
           "sql": {
             "columns": [
               {

--- a/zero-dashboards/dashboards/Commissioning/pms-dashboard.json
+++ b/zero-dashboards/dashboards/Commissioning/pms-dashboard.json
@@ -32213,10 +32213,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"PA0V\").value ORDER BY time)                  AS pre_alarm_0V,\r\n  LAST_VALUE((\"MA0V\").value ORDER BY time)                  AS main_alarm_0V,\r\n  LAST_VALUE((\"PA24V\").value ORDER BY time)                 AS pre_alarm_24V,\r\n  LAST_VALUE((\"MA24V\").value ORDER BY time)                 AS main_alarm_24V,\r\n  LAST_VALUE((\"GFDEnabled\").value ORDER BY time)            AS status_gfd_enabled,\r\n  LAST_VALUE((\"FieldVoltageAvailable\").value ORDER BY time) AS status_field_volt_available\r\nFROM marpower.\"450000_dc_distribution_pwr\"\r\nWHERE topic = 'marpower/450000-dc-distribution/pwr/keb6'",
+          "rawSql": "SELECT\r\n  timestamp                      AS time,\r\n  pa_0_v__value                  AS pre_alarm_0V,\r\n  ma_0_v__value                  AS main_alarm_0V,\r\n  pa_24_v__value                 AS pre_alarm_24V,\r\n  ma_24_v__value                 AS main_alarm_24V,\r\n  gfd_enabled__value             AS status_gfd_enabled,\r\n  field_voltage_available__value AS status_field_volt_available\r\nFROM public.marpower__450000_dc_distribution__pwr\r\nWHERE topic = 'marpower/450000-dc-distribution/pwr/keb6'\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -32828,10 +32842,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"PA0V\").value ORDER BY time)                  AS pre_alarm_0V,\r\n  LAST_VALUE((\"MA0V\").value ORDER BY time)                  AS main_alarm_0V,\r\n  LAST_VALUE((\"PA24V\").value ORDER BY time)                 AS pre_alarm_24V,\r\n  LAST_VALUE((\"MA24V\").value ORDER BY time)                 AS main_alarm_24V,\r\n  LAST_VALUE((\"GFDEnabled\").value ORDER BY time)            AS status_gfd_enabled,\r\n  LAST_VALUE((\"FieldVoltageAvailable\").value ORDER BY time) AS status_field_volt_available\r\nFROM marpower.\"450000_dc_distribution_pwr\"\r\nWHERE topic = 'marpower/450000-dc-distribution/pwr/keb7'",
+          "rawSql": "SELECT\r\n  timestamp                      AS time,\r\n  pa_0_v__value                  AS pre_alarm_0V,\r\n  ma_0_v__value                  AS main_alarm_0V,\r\n  pa_24_v__value                 AS pre_alarm_24V,\r\n  ma_24_v__value                 AS main_alarm_24V,\r\n  gfd_enabled__value             AS status_gfd_enabled,\r\n  field_voltage_available__value AS status_field_volt_available\r\nFROM public.marpower__450000_dc_distribution__pwr\r\nWHERE topic = 'marpower/450000-dc-distribution/pwr/keb7'\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -33443,10 +33471,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"PA0V\").value ORDER BY time)                  AS pre_alarm_0V,\r\n  LAST_VALUE((\"MA0V\").value ORDER BY time)                  AS main_alarm_0V,\r\n  LAST_VALUE((\"PA24V\").value ORDER BY time)                 AS pre_alarm_24V,\r\n  LAST_VALUE((\"MA24V\").value ORDER BY time)                 AS main_alarm_24V,\r\n  LAST_VALUE((\"GFDEnabled\").value ORDER BY time)            AS status_gfd_enabled,\r\n  LAST_VALUE((\"FieldVoltageAvailable\").value ORDER BY time) AS status_field_volt_available\r\nFROM marpower.\"450000_dc_distribution_pwr\"\r\nWHERE topic = 'marpower/450000-dc-distribution/pwr/keb8'",
+          "rawSql": "SELECT\r\n  timestamp                      AS time,\r\n  pa_0_v__value                  AS pre_alarm_0V,\r\n  ma_0_v__value                  AS main_alarm_0V,\r\n  pa_24_v__value                 AS pre_alarm_24V,\r\n  ma_24_v__value                 AS main_alarm_24V,\r\n  gfd_enabled__value             AS status_gfd_enabled,\r\n  field_voltage_available__value AS status_field_volt_available\r\nFROM public.marpower__450000_dc_distribution__pwr\r\nWHERE topic = 'marpower/450000-dc-distribution/pwr/keb8'\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -34058,10 +34100,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"PA0V\").value ORDER BY time)                  AS pre_alarm_0V,\r\n  LAST_VALUE((\"MA0V\").value ORDER BY time)                  AS main_alarm_0V,\r\n  LAST_VALUE((\"PA24V\").value ORDER BY time)                 AS pre_alarm_24V,\r\n  LAST_VALUE((\"MA24V\").value ORDER BY time)                 AS main_alarm_24V,\r\n  LAST_VALUE((\"GFDEnabled\").value ORDER BY time)            AS status_gfd_enabled,\r\n  LAST_VALUE((\"FieldVoltageAvailable\").value ORDER BY time) AS status_field_volt_available\r\nFROM marpower.\"450000_dc_distribution_pwr\"\r\nWHERE topic = 'marpower/450000-dc-distribution/pwr/keb9'",
+          "rawSql": "SELECT\r\n  timestamp                      AS time,\r\n  pa_0_v__value                  AS pre_alarm_0V,\r\n  ma_0_v__value                  AS main_alarm_0V,\r\n  pa_24_v__value                 AS pre_alarm_24V,\r\n  ma_24_v__value                 AS main_alarm_24V,\r\n  gfd_enabled__value             AS status_gfd_enabled,\r\n  field_voltage_available__value AS status_field_volt_available\r\nFROM public.marpower__450000_dc_distribution__pwr\r\nWHERE topic = 'marpower/450000-dc-distribution/pwr/keb9'\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -34673,10 +34729,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"KEB1_PA0V\").value ORDER BY time)                  AS pre_alarm_0V,\r\n  LAST_VALUE((\"KEB1_MA0V\").value ORDER BY time)                  AS main_alarm_0V,\r\n  LAST_VALUE((\"KEB1_PA24V\").value ORDER BY time)                 AS pre_alarm_24V,\r\n  LAST_VALUE((\"KEB1_MA24V\").value ORDER BY time)                 AS main_alarm_24V,\r\n  LAST_VALUE((\"KEB1_GFDEnabled\").value ORDER BY time)            AS status_gfd_enabled,\r\n  LAST_VALUE((\"KEB1_FieldVoltageAvailable\").value ORDER BY time) AS status_field_volt_available\r\nFROM marpower.\"450000_amcs\"",
+          "rawSql": "SELECT\r\n  timestamp                            AS time,\r\n  keb_1_pa_0_v__value                  AS pre_alarm_0V,\r\n  keb_1_ma_0_v__value                  AS main_alarm_0V,\r\n  keb_1_pa_24_v__value                 AS pre_alarm_24V,\r\n  keb_1_ma_24_v__value                 AS main_alarm_24V,\r\n  keb_1_gfd_enabled__value             AS status_gfd_enabled,\r\n  keb_1_field_voltage_available__value AS status_field_volt_available\r\nFROM public.marpower__450000_amcs\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -35288,10 +35358,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"KEB2_PA0V\").value ORDER BY time)                  AS pre_alarm_0V,\r\n  LAST_VALUE((\"KEB2_MA0V\").value ORDER BY time)                  AS main_alarm_0V,\r\n  LAST_VALUE((\"KEB2_PA24V\").value ORDER BY time)                 AS pre_alarm_24V,\r\n  LAST_VALUE((\"KEB2_MA24V\").value ORDER BY time)                 AS main_alarm_24V,\r\n  LAST_VALUE((\"KEB2_GFDEnabled\").value ORDER BY time)            AS status_gfd_enabled,\r\n  LAST_VALUE((\"KEB2_FieldVoltageAvailable\").value ORDER BY time) AS status_field_volt_available\r\nFROM marpower.\"450000_amcs\"",
+          "rawSql": "SELECT\r\n  timestamp                            AS time,\r\n  keb_2_pa_0_v__value                  AS pre_alarm_0V,\r\n  keb_2_ma_0_v__value                  AS main_alarm_0V,\r\n  keb_2_pa_24_v__value                 AS pre_alarm_24V,\r\n  keb_2_ma_24_v__value                 AS main_alarm_24V,\r\n  keb_2_gfd_enabled__value             AS status_gfd_enabled,\r\n  keb_2_field_voltage_available__value AS status_field_volt_available\r\nFROM public.marpower__450000_amcs\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [

--- a/zero-dashboards/dashboards/Commissioning/pms-dashboard.json
+++ b/zero-dashboards/dashboards/Commissioning/pms-dashboard.json
@@ -24328,10 +24328,24 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
           "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"KEB7_UGRID_AFT_DIGIN1\").value ORDER BY time) AS aft_dig_in1,\r\n  LAST_VALUE((\"KEB7_UGRID_AFT_DIGIN2\").value ORDER BY time) AS aft_dig_in2,\r\n  LAST_VALUE((\"KEB9_UGRID_FWD_DIGIN1\").value ORDER BY time) AS fwd_dig_in1,\r\n  LAST_VALUE((\"KEB9_UGRID_FWD_DIGIN2\").value ORDER BY time) AS fwd_dig_in2\r\nFROM marpower.\"450000_dc_distribution_general\"",
+          "rawSql": "SELECT\r\n  timestamp                      AS time,\r\n  keb_7_ugrid_aft_digin_1__value AS aft_dig_in1,\r\n  keb_7_ugrid_aft_digin_2__value AS aft_dig_in2,\r\n  keb_9_ugrid_fwd_digin_1__value AS fwd_dig_in1,\r\n  keb_9_ugrid_fwd_digin_2__value AS fwd_dig_in2\r\nFROM public.marpower__450000_dc_distribution_general\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "B",
           "sql": {
             "columns": [
@@ -24756,9 +24770,23 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"ENABLE\").value ORDER BY time)         AS enable,\r\n  LAST_VALUE((\"ENABLEFIRMWARE\").value ORDER BY time) AS enable_firmware_update,\r\n  LAST_VALUE((\"DIGOUT1\").value ORDER BY time)        AS digital_output1,\r\n  LAST_VALUE((\"DIGOUT2\").value ORDER BY time)        AS digital_output2\r\nFROM marpower.\"450000_ugrid\"\r\nWHERE topic = 'marpower/450000-ugrid/aft'",
+          "rawSql": "SELECT\r\n  timestamp             AS time,\r\n  ugrid_aft_digout_1__value       AS digital_output1,\r\n  ugrid_aft_digout_2__value       AS digital_output2\r\nFROM public.marpower__450000_ugrid\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -25183,9 +25211,23 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"ENABLE\").value ORDER BY time)         AS enable,\r\n  LAST_VALUE((\"ENABLEFIRMWARE\").value ORDER BY time) AS enable_firmware_update,\r\n  LAST_VALUE((\"DIGOUT1\").value ORDER BY time)        AS digital_output1,\r\n  LAST_VALUE((\"DIGOUT2\").value ORDER BY time)        AS digital_output2\r\nFROM marpower.\"450000_ugrid\"\r\nWHERE topic = 'marpower/450000-ugrid/fwd'",
+          "rawSql": "SELECT\r\n  timestamp             AS time,\r\n  ugrid_fwd_digout_1__value       AS digital_output1,\r\n  ugrid_fwd_digout_2__value       AS digital_output2\r\nFROM public.marpower__450000_ugrid\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -25973,9 +26015,23 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"WINDINGTEMPU1\").value ORDER BY time) AS winding_U1_temp,\r\n  LAST_VALUE((\"WINDINGTEMPV1\").value ORDER BY time) AS winding_V1_temp,\r\n  LAST_VALUE((\"WINDINGTEMPW1\").value ORDER BY time) AS winding_W1_temp,\r\n  LAST_VALUE((\"WINDINGTEMPU2\").value ORDER BY time) AS winding_U2_temp,\r\n  LAST_VALUE((\"WINDINGTEMPV2\").value ORDER BY time) AS winding_V2_temp,\r\n  LAST_VALUE((\"WINDINGTEMPW2\").value ORDER BY time) AS winding_W2_temp,\r\n  LAST_VALUE((\"LCFILTTEMPU\").value ORDER BY time)   AS lc_filter_U_temp,\r\n  LAST_VALUE((\"LCFILTTEMPV\").value ORDER BY time)   AS lc_filter_V_temp,\r\n  LAST_VALUE((\"LCFILTTEMPW\").value ORDER BY time)   AS lc_filter_W_temp\r\nFROM marpower.\"450000_dynamic_conv_ps_general\"",
+          "rawSql": "SELECT\r\n  timestamp             AS time,\r\n  windingtempu_1__value AS winding_U1_temp,\r\n  windingtempv_1__value AS winding_V1_temp,\r\n  windingtempw_1__value AS winding_W1_temp,\r\n  windingtempu_2__value AS winding_U2_temp,\r\n  windingtempv_2__value AS winding_V2_temp,\r\n  windingtempw_2__value AS winding_W2_temp,\r\n  lcfilttempu__value    AS lc_filter_U_temp,\r\n  lcfilttempv__value    AS lc_filter_V_temp,\r\n  lcfilttempw__value    AS lc_filter_W_temp\r\nFROM public.marpower__450000_dynamic_conv_ps_general\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [
@@ -26763,9 +26819,23 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "format": "table",
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "2.1.4",
+          "queryType": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  LAST_VALUE(time ORDER BY time) AS time,\r\n  LAST_VALUE((\"WINDINGTEMPU1\").value ORDER BY time) AS winding_U1_temp,\r\n  LAST_VALUE((\"WINDINGTEMPV1\").value ORDER BY time) AS winding_V1_temp,\r\n  LAST_VALUE((\"WINDINGTEMPW1\").value ORDER BY time) AS winding_W1_temp,\r\n  LAST_VALUE((\"WINDINGTEMPU2\").value ORDER BY time) AS winding_U2_temp,\r\n  LAST_VALUE((\"WINDINGTEMPV2\").value ORDER BY time) AS winding_V2_temp,\r\n  LAST_VALUE((\"WINDINGTEMPW2\").value ORDER BY time) AS winding_W2_temp,\r\n  LAST_VALUE((\"LCFILTTEMPU\").value ORDER BY time)   AS lc_filter_U_temp,\r\n  LAST_VALUE((\"LCFILTTEMPV\").value ORDER BY time)   AS lc_filter_V_temp,\r\n  LAST_VALUE((\"LCFILTTEMPW\").value ORDER BY time)   AS lc_filter_W_temp\r\nFROM marpower.\"450000_dynamic_conv_sb_general\"",
+          "rawSql": "SELECT\r\n  timestamp             AS time,\r\n  windingtempu_1__value AS winding_U1_temp,\r\n  windingtempv_1__value AS winding_V1_temp,\r\n  windingtempw_1__value AS winding_W1_temp,\r\n  windingtempu_2__value AS winding_U2_temp,\r\n  windingtempv_2__value AS winding_V2_temp,\r\n  windingtempw_2__value AS winding_W2_temp,\r\n  lcfilttempu__value    AS lc_filter_U_temp,\r\n  lcfilttempv__value    AS lc_filter_V_temp,\r\n  lcfilttempw__value    AS lc_filter_W_temp\r\nFROM public.marpower__450000_dynamic_conv_sb_general\r\nORDER BY timestamp DESC\r\nLIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [


### PR DESCRIPTION
All queries have been changed for greptime. Only data points that were missing in the Greptime DB were the `Heartbeat` & `Undervoltage` status bits of the KEB8 DC Switch 05.76:
<img width="259" height="141" alt="afbeelding" src="https://github.com/user-attachments/assets/28d4791f-68ca-49e0-990b-adc9806d648e" />


[ZERO-1754](https://foundationzero-team.atlassian.net/browse/ZERO-1754)

[ZERO-1754]: https://foundationzero-team.atlassian.net/browse/ZERO-1754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ