### PR TITLE
Update bypass flow yard tag

### DIFF
--- a/zero-thrs-control/src/thrs/input_output/modules/consumers.py
+++ b/zero-thrs-control/src/thrs/input_output/modules/consumers.py
@@ -35,7 +35,7 @@ class ConsumersSensorValues(ThrsValues):
     ]
     consumers_flow_bypass: Annotated[
         sensor.FlowSensor,
-        component_meta(yard_tag="50001060-01", component_type="flow_sensor"),
+        component_meta(yard_tag="50001192", component_type="flow_sensor"),
     ]
     consumers_flowcontrol_fahrenheit: Annotated[
         sensor.Valve,


### PR DESCRIPTION
Changed in revision 10, but the text wasn't correct
<img width="604" height="103" alt="image" src="https://github.com/user-attachments/assets/7c24e23c-fc36-4d61-9c00-a0ee66db266d" />
