### PR TITLE
Refactor control module definitions to make code more readable

### DIFF
--- a/zero-thrs-control/src/thrs/cli/simulation_controls.py
+++ b/zero-thrs-control/src/thrs/cli/simulation_controls.py
@@ -20,34 +20,29 @@ from pydantic import (
 )
 
 from thrs.control.modules.boilers import (
-    BoilersAlarms,
+    BOILERS_MODULE_DESCRIPTION,
     BoilersControl,
-    BoilersControlMode,
     BoilersParameters,
 )
 from thrs.control.modules.consumers import (
-    ConsumersAlarms,
+    CONSUMERS_MODULE_DESCRIPTION,
     ConsumersControl,
-    ConsumersControlMode,
     ConsumersParameters,
 )
 from thrs.control.modules.high_temperature import HighTemperatureModule
 from thrs.control.modules.pcm import (
-    PcmAlarms,
+    PCM_MODULE_DESCRIPTION,
     PcmControl,
-    PcmControlMode,
     PcmParameters,
 )
 from thrs.control.modules.pvt import (
-    PvtAlarms,
+    PVT_MODULE_DESCRIPTION,
     PvtControl,
-    PvtControlMode,
     PvtParameters,
 )
 from thrs.control.modules.thrusters import (
-    ThrustersAlarms,
+    THRUSTERS_MODULE_DESCRIPTION,
     ThrustersControl,
-    ThrustersControlMode,
     ThrustersParameters,
 )
 from thrs.control.switching import SwitchingControlMode
@@ -70,39 +65,23 @@ from thrs.input_output.definitions.simulation import (
 )
 from thrs.input_output.definitions.units import PcsMode
 from thrs.input_output.modules.boilers import (
-    BoilersControlValues,
-    BoilersSensorValues,
     BoilersSimulationInputs,
     BoilersSimulationOutputs,
 )
 from thrs.input_output.modules.consumers import (
-    ConsumersControlValues,
-    ConsumersSensorValues,
     ConsumersSimulationInputs,
     ConsumersSimulationOutputs,
 )
 from thrs.input_output.modules.high_temperature import HighTemperatureSimulationInputs
-from thrs.input_output.modules.pcm import (
-    PcmControlValues,
-    PcmSensorValues,
-    PcmSimulationInputs,
-    PcmSimulationOutputs,
-)
-from thrs.input_output.modules.pvt import (
-    PvtControlValues,
-    PvtSensorValues,
-    PvtSimulationInputs,
-    PvtSimulationOutputs,
-)
+from thrs.input_output.modules.pcm import PcmSimulationInputs, PcmSimulationOutputs
+from thrs.input_output.modules.pvt import PvtSimulationInputs, PvtSimulationOutputs
 from thrs.input_output.modules.thrusters import (
-    ThrustersControlValues,
-    ThrustersSensorValues,
     ThrustersSimulationInputs,
     ThrustersSimulationOutputs,
 )
 from thrs.orchestration.config import Config
 from thrs.orchestration.executor import MqttExecutor, SimulationExecutor
-from thrs.orchestration.module import CombinedControl, CombinedModule, ModuleDescription
+from thrs.orchestration.module import CombinedControl, CombinedModule
 from thrs.orchestration.simulator import Simulator
 from thrs.simulation.fmu import Fmu
 from thrs.simulation.models.fmu_paths import (
@@ -244,51 +223,11 @@ CONTROLS = {
     "boilers": BoilersControl,
 }
 
-THRUSTERS_MODULE_DESCRIPTION = ModuleDescription(
-    ThrustersSensorValues,
-    ThrustersControlValues,
-    ThrustersParameters,
-    ThrustersControl,
-    ThrustersControlMode,
-    ThrustersAlarms,
-)
+type Modes = Literal[
+    "thrusters", "pvt", "pcm", "consumers", "high_temperature", "boilers"
+]
 
-PVT_MODULE_DESCRIPTION = ModuleDescription(
-    PvtSensorValues,
-    PvtControlValues,
-    PvtParameters,
-    PvtControl,
-    PvtControlMode,
-    PvtAlarms,
-)
-
-PCM_MODULE_DESCRIPTION = ModuleDescription(
-    PcmSensorValues,
-    PcmControlValues,
-    PcmParameters,
-    PcmControl,
-    PcmControlMode,
-    PcmAlarms,
-)
-CONSUMERS_MODULE_DESCRIPTION = ModuleDescription(
-    ConsumersSensorValues,
-    ConsumersControlValues,
-    ConsumersParameters,
-    ConsumersControl,
-    ConsumersControlMode,
-    ConsumersAlarms,
-)
-
-BOILERS_MODULE_DESCRIPTION = ModuleDescription(
-    BoilersSensorValues,
-    BoilersControlValues,
-    BoilersParameters,
-    BoilersControl,
-    BoilersControlMode,
-    BoilersAlarms,
-)
-
-MODES: dict[str, tuple[str, CombinedModule]] = {
+MODES: dict[Modes, tuple[str, CombinedModule]] = {
     "thrusters": (
         thrusters_path,
         CombinedModule(
@@ -341,8 +280,6 @@ MODES: dict[str, tuple[str, CombinedModule]] = {
         ),
     ),
 }
-
-Modes = Literal["thrusters", "pvt", "pcm", "consumers", "high_temperature", "boilers"]
 
 
 @dataclass

--- a/zero-thrs-control/src/thrs/control/base.py
+++ b/zero-thrs-control/src/thrs/control/base.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+from typing import Callable
+
+from thrs.classes.control import Control
+from thrs.input_output.alarms import BaseAlarms
+from thrs.input_output.base import ThrsValues
+
+
+class ModuleDescription[
+    S: ThrsValues,
+    C: ThrsValues,
+    P: ThrsValues,
+    M: ThrsValues,
+]:
+    """Description of a module with sensor values, control values, control parameters and control mode models and the control & alarm logic"""
+
+    def __init__(
+        self,
+        sensor_values_cls: type[S],
+        control_values_cls: type[C],
+        parameters_cls: type[P],
+        control: Callable[[P, Callable[[], datetime]], Control[S, C, P, M]],
+        control_mode_cls: type[M],
+        alarms: Callable[[], BaseAlarms[S, C, P]],
+    ):
+        self.sensor_values_cls = sensor_values_cls
+        self.control_values_cls = control_values_cls
+        self.parameters_cls = parameters_cls
+        self.control_mode_cls = control_mode_cls
+        self.control = control
+        self.alarms = alarms

--- a/zero-thrs-control/src/thrs/control/modules/boilers.py
+++ b/zero-thrs-control/src/thrs/control/modules/boilers.py
@@ -5,6 +5,7 @@ from pydantic import Field, model_validator
 from transitions import Machine, State
 
 from thrs.classes.control import Control, ControlMode, ControlResult
+from thrs.control.base import ModuleDescription
 from thrs.control.controllers import PidController
 from thrs.input_output.alarms import BaseAlarms, Severity, alarm
 from thrs.input_output.base import Stamped, ThrsValues
@@ -1063,3 +1064,13 @@ class BoilersAlarms(BaseAlarms):
             BoilersSensorValues.yard_tag("boilers_level_tank3"),
             270,
         )
+
+
+BOILERS_MODULE_DESCRIPTION = ModuleDescription(
+    BoilersSensorValues,
+    BoilersControlValues,
+    BoilersParameters,
+    BoilersControl,
+    BoilersControlMode,
+    BoilersAlarms,
+)

--- a/zero-thrs-control/src/thrs/control/modules/consumers.py
+++ b/zero-thrs-control/src/thrs/control/modules/consumers.py
@@ -4,6 +4,7 @@ from typing import Annotated, Callable
 from pydantic import Field
 
 from thrs.classes.control import Control, ControlMode, ControlResult
+from thrs.control.base import ModuleDescription
 from thrs.control.controllers import (
     FlowDistributionController,
     PidController,
@@ -186,3 +187,13 @@ class ConsumersControl(
 
 class ConsumersAlarms(BaseAlarms):
     pass
+
+
+CONSUMERS_MODULE_DESCRIPTION = ModuleDescription(
+    ConsumersSensorValues,
+    ConsumersControlValues,
+    ConsumersParameters,
+    ConsumersControl,
+    ConsumersControlMode,
+    ConsumersAlarms,
+)

--- a/zero-thrs-control/src/thrs/control/modules/converters.py
+++ b/zero-thrs-control/src/thrs/control/modules/converters.py
@@ -5,7 +5,6 @@ from transitions import Machine, State
 
 from thrs.classes.control import Control, ControlMode, ControlResult
 from thrs.control.controllers import PidController
-from thrs.input_output.alarms import BaseAlarms
 from thrs.input_output.base import Stamped, ThrsValues
 from thrs.input_output.definitions import control, sensor
 from thrs.input_output.definitions.control import Valve
@@ -79,8 +78,8 @@ class ConvertersControl(
     def __init__(
         self,
         parameters: ConvertersParameters,
-        initial_control_values: ConvertersControlValues,
         time_fn: Callable[[], datetime],
+        initial_control_values: ConvertersControlValues,
     ) -> None:
         self._parameters = parameters
         self._time = time_fn
@@ -218,7 +217,3 @@ class ConvertersControl(
                 switch.setpoint = Stamped(value=Valve.OPEN, timestamp=self._time())
             elif switch.setpoint.value == Valve.OPEN and not converter.active.value:
                 switch.setpoint = Stamped(value=Valve.CLOSED, timestamp=self._time())
-
-
-class ConvertersAlarms(BaseAlarms):
-    pass

--- a/zero-thrs-control/src/thrs/control/modules/fahrenheit.py
+++ b/zero-thrs-control/src/thrs/control/modules/fahrenheit.py
@@ -5,7 +5,9 @@ from pydantic import model_validator
 from transitions import Machine, State
 
 from thrs.classes.control import Control, ControlMode, ControlResult
+from thrs.control.base import ModuleDescription
 from thrs.control.controllers import PidController
+from thrs.input_output.alarms import BaseAlarms
 from thrs.input_output.base import Stamped, ThrsValues
 from thrs.input_output.definitions.control import Fahrenheit, Valve
 from thrs.input_output.definitions.units import (
@@ -310,3 +312,17 @@ class FahrenheitControl(
             - self._parameters.fahrenheit_hot_minimum,
             timestamp=self._time(),
         )
+
+
+class FahrenheitAlarms(BaseAlarms):
+    pass
+
+
+FAHRENHEIT_MODULE_DESCRIPTION = ModuleDescription(
+    FahrenheitSensorValues,
+    FahrenheitControlValues,
+    FahrenheitParameters,
+    FahrenheitControl,
+    FahrenheitControlMode,
+    FahrenheitAlarms,
+)

--- a/zero-thrs-control/src/thrs/control/modules/high_temperature.py
+++ b/zero-thrs-control/src/thrs/control/modules/high_temperature.py
@@ -1,83 +1,28 @@
-from thrs.control.modules.consumers import (
-    ConsumersAlarms,
-    ConsumersControl,
-    ConsumersControlMode,
-    ConsumersParameters,
-)
-from thrs.control.modules.pcm import (
-    PcmAlarms,
-    PcmControl,
-    PcmControlMode,
-    PcmParameters,
-)
-from thrs.control.modules.pvt import (
-    PvtAlarms,
-    PvtControl,
-    PvtControlMode,
-    PvtParameters,
-)
-from thrs.control.modules.thrusters import (
-    ThrustersAlarms,
-    ThrustersControl,
-    ThrustersControlMode,
-    ThrustersParameters,
-)
-from thrs.input_output.modules.consumers import (
-    ConsumersControlValues,
-    ConsumersSensorValues,
-)
+from thrs.control.base import ModuleDescription
+from thrs.control.modules.consumers import CONSUMERS_MODULE_DESCRIPTION
+from thrs.control.modules.pcm import PCM_MODULE_DESCRIPTION
+from thrs.control.modules.pvt import PVT_MODULE_DESCRIPTION
+from thrs.control.modules.thrusters import THRUSTERS_MODULE_DESCRIPTION
 from thrs.input_output.modules.high_temperature import (
     HighTemperatureSimulationInputs,
     HighTemperatureSimulationOutputs,
 )
-from thrs.input_output.modules.pcm import PcmControlValues, PcmSensorValues
-from thrs.input_output.modules.pvt import PvtControlValues, PvtSensorValues
-from thrs.input_output.modules.thrusters import (
-    ThrustersControlValues,
-    ThrustersSensorValues,
-)
-from thrs.orchestration.module import CombinedModule, ModuleDescription
+from thrs.orchestration.module import CombinedModule
 
 
 class HighTemperatureModule(
     CombinedModule[HighTemperatureSimulationInputs, HighTemperatureSimulationOutputs]
 ):
     def __init__(self, control_topic_suffix: str | None = None):
+        modules: dict[str, ModuleDescription] = {
+            "thrusters": THRUSTERS_MODULE_DESCRIPTION,
+            "pvt": PVT_MODULE_DESCRIPTION,
+            "pcm": PCM_MODULE_DESCRIPTION,
+            "consumers": CONSUMERS_MODULE_DESCRIPTION,
+        }
+
         super().__init__(
-            {
-                "thrusters": ModuleDescription(
-                    ThrustersSensorValues,
-                    ThrustersControlValues,
-                    ThrustersParameters,
-                    ThrustersControl,
-                    ThrustersControlMode,
-                    ThrustersAlarms,
-                ),
-                "pvt": ModuleDescription(
-                    PvtSensorValues,
-                    PvtControlValues,
-                    PvtParameters,
-                    PvtControl,
-                    PvtControlMode,
-                    PvtAlarms,
-                ),
-                "pcm": ModuleDescription(
-                    PcmSensorValues,
-                    PcmControlValues,
-                    PcmParameters,
-                    PcmControl,
-                    PcmControlMode,
-                    PcmAlarms,
-                ),
-                "consumers": ModuleDescription(
-                    ConsumersSensorValues,
-                    ConsumersControlValues,
-                    ConsumersParameters,
-                    ConsumersControl,
-                    ConsumersControlMode,
-                    ConsumersAlarms,
-                ),
-            },
+            modules,
             HighTemperatureSimulationInputs,
             HighTemperatureSimulationOutputs,
             control_topic_suffix=control_topic_suffix,

--- a/zero-thrs-control/src/thrs/control/modules/lt1.py
+++ b/zero-thrs-control/src/thrs/control/modules/lt1.py
@@ -4,6 +4,7 @@ from typing import Callable, Literal
 from transitions import Machine, State
 
 from thrs.classes.control import Control, ControlMode, ControlResult
+from thrs.control.base import ModuleDescription
 from thrs.control.controllers import FlowBalanceController, PidController
 from thrs.control.modules.thrusters import ThrustersControlMode
 from thrs.input_output.alarms import BaseAlarms
@@ -425,3 +426,13 @@ class Lt1Control(
 
 class Lt1Alarms(BaseAlarms):
     pass
+
+
+LT1_MODULE_DESCRIPTION = ModuleDescription(
+    Lt1SensorValues,
+    Lt1ControlValues,
+    Lt1Parameters,
+    Lt1Control,
+    Lt1ControlMode,
+    Lt1Alarms,
+)

--- a/zero-thrs-control/src/thrs/control/modules/lt2.py
+++ b/zero-thrs-control/src/thrs/control/modules/lt2.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Callable
 
 from thrs.classes.control import Control, ControlMode, ControlResult
+from thrs.control.base import ModuleDescription
 from thrs.control.controllers import PidController
 from thrs.control.modules.converters import (
     ConvertersControl,
@@ -155,7 +156,7 @@ class Lt2Control(
 
         self._brightloops_aft_control = ConvertersControl(
             brightloops_aft_parameters(parameters),
-            ConvertersControlValues(
+            initial_control_values=ConvertersControlValues(
                 pump=self._current_values.lt2_pump_aft,
                 mix=self._current_values.lt2_mix_aft,
                 switches=[
@@ -170,7 +171,7 @@ class Lt2Control(
 
         self._brightloops_fwd_control = ConvertersControl(
             brightloops_fwd_parameters(parameters),
-            ConvertersControlValues(
+            initial_control_values=ConvertersControlValues(
                 pump=self._current_values.lt2_pump_fwd,
                 mix=self._current_values.lt2_mix_fwd,
                 switches=[
@@ -183,7 +184,7 @@ class Lt2Control(
 
         self._ugrids_control = ConvertersControl(
             ugrids_parameters(parameters),
-            ConvertersControlValues(
+            initial_control_values=ConvertersControlValues(
                 pump=self._current_values.lt2_pump_ugrid,
                 mix=self._current_values.lt2_mix_ugrid,
                 switches=[
@@ -379,3 +380,13 @@ class Lt2Control(
 
 class Lt2Alarms(BaseAlarms):
     pass
+
+
+LT2_MODULE_DESCRIPTION = ModuleDescription(
+    Lt2SensorValues,
+    Lt2ControlValues,
+    Lt2Parameters,
+    Lt2Control,
+    Lt2ControlMode,
+    Lt2Alarms,
+)

--- a/zero-thrs-control/src/thrs/control/modules/pcm.py
+++ b/zero-thrs-control/src/thrs/control/modules/pcm.py
@@ -4,6 +4,7 @@ from typing import Callable
 from transitions import Machine, State
 
 from thrs.classes.control import Control, ControlMode, ControlResult
+from thrs.control.base import ModuleDescription
 from thrs.control.controllers import FlowBalanceController, PidController
 from thrs.input_output.alarms import BaseAlarms
 from thrs.input_output.base import Stamped, ThrsValues
@@ -419,3 +420,13 @@ class PcmControl(
 
 class PcmAlarms(BaseAlarms):
     pass
+
+
+PCM_MODULE_DESCRIPTION = ModuleDescription(
+    PcmSensorValues,
+    PcmControlValues,
+    PcmParameters,
+    PcmControl,
+    PcmControlMode,
+    PcmAlarms,
+)

--- a/zero-thrs-control/src/thrs/control/modules/pvt.py
+++ b/zero-thrs-control/src/thrs/control/modules/pvt.py
@@ -4,6 +4,7 @@ from typing import Annotated, Callable
 from pydantic import Field, model_validator
 
 from thrs.classes.control import Control, ControlMode, ControlResult
+from thrs.control.base import ModuleDescription
 from thrs.control.controllers import PidController
 from thrs.control.modules.pvt_group import (
     PvtGroupControl,
@@ -167,27 +168,27 @@ class PvtControl(
 
         self._main_fwd_control = PvtGroupControl(
             main_pvt_group_parameters(parameters),
-            PvtGroupControlValues(
+            initial_control_values=PvtGroupControlValues(
                 pump=self._current_values.pvt_pump_main_fwd,
                 mix=self._current_values.pvt_mix_main_fwd,
             ),
-            time_fn,
+            time_fn=time_fn,
         )
         self._main_aft_control = PvtGroupControl(
             aft_pvt_group_parameters(parameters),
-            PvtGroupControlValues(
+            initial_control_values=PvtGroupControlValues(
                 pump=self._current_values.pvt_pump_main_aft,
                 mix=self._current_values.pvt_mix_main_aft,
             ),
-            time_fn,
+            time_fn=time_fn,
         )
         self._owners_control = PvtGroupControl(
             owners_pvt_group_parameters(parameters),
-            PvtGroupControlValues(
+            initial_control_values=PvtGroupControlValues(
                 pump=self._current_values.pvt_pump_owners,
                 mix=self._current_values.pvt_mix_owners,
             ),
-            time_fn,
+            time_fn=time_fn,
         )
 
     @property
@@ -295,3 +296,13 @@ class PvtControl(
 
 class PvtAlarms(BaseAlarms):
     pass
+
+
+PVT_MODULE_DESCRIPTION = ModuleDescription(
+    PvtSensorValues,
+    PvtControlValues,
+    PvtParameters,
+    PvtControl,
+    PvtControlMode,
+    PvtAlarms,
+)

--- a/zero-thrs-control/src/thrs/control/modules/pvt_group.py
+++ b/zero-thrs-control/src/thrs/control/modules/pvt_group.py
@@ -63,8 +63,8 @@ class PvtGroupControl(
     def __init__(
         self,
         parameters: PvtGroupParameters,
-        initial_control_values: PvtGroupControlValues,
         time_fn: Callable[[], datetime],
+        initial_control_values: PvtGroupControlValues,
     ) -> None:
         self._parameters = parameters
         self._time = time_fn

--- a/zero-thrs-control/src/thrs/control/modules/thrusters.py
+++ b/zero-thrs-control/src/thrs/control/modules/thrusters.py
@@ -5,6 +5,7 @@ from pydantic import model_validator
 from transitions import Machine, State
 
 from thrs.classes.control import Control, ControlMode, ControlResult
+from thrs.control.base import ModuleDescription
 from thrs.control.controllers import FlowBalanceController, PidController
 from thrs.input_output.alarms import BaseAlarms, Severity, alarm
 from thrs.input_output.base import Stamped, ThrsValues
@@ -524,3 +525,13 @@ class ThrustersAlarms(BaseAlarms):
         if sensor_values.thrusters_temperature_supply.temperature.value > 95:
             return "Thrusters supply temperature above 95 °C"
         return None
+
+
+THRUSTERS_MODULE_DESCRIPTION = ModuleDescription(
+    ThrustersSensorValues,
+    ThrustersControlValues,
+    ThrustersParameters,
+    ThrustersControl,
+    ThrustersControlMode,
+    ThrustersAlarms,
+)

--- a/zero-thrs-control/src/thrs/orchestration/module.py
+++ b/zero-thrs-control/src/thrs/orchestration/module.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Callable, Literal, Mapping, Protocol
 
 from thrs.classes.control import Control, ControlResult
+from thrs.control.base import ModuleDescription
 from thrs.control.manual import ManualControl
 from thrs.control.switching import SwitchingControl, SwitchingControlMode
 from thrs.input_output.alarms import Alarm, BaseAlarms
@@ -18,31 +19,6 @@ from thrs.input_output.model_builder import (
 )
 from thrs.simulation.io_mapping import CombinedIoMapping, IoMapping
 from thrs.utils.string import hyphenize
-
-
-class ModuleDescription[
-    S: ThrsValues,
-    C: ThrsValues,
-    P: ThrsValues,
-    M: ThrsValues,
-]:
-    """Description of a module with sensor values, control values, control parameters and control mode models and the control & alarm logic"""
-
-    def __init__(
-        self,
-        sensor_values_cls: type[S],
-        control_values_cls: type[C],
-        parameters_cls: type[P],
-        control: Callable[[P, Callable[[], datetime]], Control[S, C, P, M]],
-        control_mode_cls: type[M],
-        alarms: Callable[[], BaseAlarms[S, C, P]],
-    ):
-        self.sensor_values_cls = sensor_values_cls
-        self.control_values_cls = control_values_cls
-        self.parameters_cls = parameters_cls
-        self.control_mode_cls = control_mode_cls
-        self.control = control
-        self.alarms = alarms
 
 
 class MqttMapping[M](Protocol):


### PR DESCRIPTION
Move ModuleDescriptions to the respective control modules to reduce the number of imports.
And  to make it clear what its needed for control module to exist... 