### PR TITLE
Add max_packet_size configuration to vector

### DIFF
--- a/vector/config.yaml
+++ b/vector/config.yaml
@@ -17,6 +17,7 @@ sources:
       - "hull-temperature/temperatures"
     user: "${MQTT_USER}"
     password: "${MQTT_PASSWORD}"
+    max_packet_size: 163840
 transforms:
   process:
     type: remap


### PR DESCRIPTION
10240 by default [https://vector.dev/docs/reference/configuration/sources/mqtt/#max_packet_size]
<img width="1260" height="1962" alt="image" src="https://github.com/user-attachments/assets/1e13aae9-0ac7-4b79-951f-62e65b43855a" />
