### PR TITLE
Move Mqtt related stuff to connector.py and Simulation related stuff to simulation.py

### DIFF
--- a/zero-thrs-control/src/thrs/cli/simulation_controls.py
+++ b/zero-thrs-control/src/thrs/cli/simulation_controls.py
@@ -758,7 +758,9 @@ class SimulationControls:
                 self._control_client,
                 self._sensor_client,
                 self._topic_prefix,
-                modules,
+                modules.sensor_values_mqtt_mapping,
+                modules.control_values_mqtt_mapping,
+                modules.simulation_output_mqtt_mapping,
             )
             runner = Runner(connector, control, modules.alarms())  # type: ignore
 

--- a/zero-thrs-control/src/thrs/cli/simulation_controls.py
+++ b/zero-thrs-control/src/thrs/cli/simulation_controls.py
@@ -194,7 +194,7 @@ type Modes = Literal[
     "thrusters", "pvt", "pcm", "consumers", "high_temperature", "boilers"
 ]
 
-MODES: dict[Modes, tuple[str, CombinedModule]] = {
+MODES: dict[Modes, tuple[str, CombinedModule, str]] = {
     "thrusters": (
         thrusters_path,
         CombinedModule(
@@ -203,8 +203,8 @@ MODES: dict[Modes, tuple[str, CombinedModule]] = {
             },
             ThrustersSimulationInputs,
             ThrustersSimulationOutputs,
-            control_topic_suffix=settings.mqtt_control_topic_suffix,
         ),
+        settings.mqtt_control_topic_suffix,
     ),
     "pvt": (
         pvt_path,
@@ -212,8 +212,8 @@ MODES: dict[Modes, tuple[str, CombinedModule]] = {
             {"pvt": PVT_MODULE_DESCRIPTION},
             PvtSimulationInputs,
             PvtSimulationOutputs,
-            control_topic_suffix=settings.mqtt_control_topic_suffix,
         ),
+        settings.mqtt_control_topic_suffix,
     ),
     "pcm": (
         pcm_path,
@@ -221,8 +221,8 @@ MODES: dict[Modes, tuple[str, CombinedModule]] = {
             {"pcm": PCM_MODULE_DESCRIPTION},
             PcmSimulationInputs,
             PcmSimulationOutputs,
-            control_topic_suffix=settings.mqtt_control_topic_suffix,
         ),
+        settings.mqtt_control_topic_suffix,
     ),
     "consumers": (
         consumers_path,
@@ -230,8 +230,8 @@ MODES: dict[Modes, tuple[str, CombinedModule]] = {
             {"consumers": CONSUMERS_MODULE_DESCRIPTION},
             ConsumersSimulationInputs,
             ConsumersSimulationOutputs,
-            control_topic_suffix=settings.mqtt_control_topic_suffix,
         ),
+        settings.mqtt_control_topic_suffix,
     ),
     "high_temperature": (
         high_temperature_path,
@@ -244,8 +244,8 @@ MODES: dict[Modes, tuple[str, CombinedModule]] = {
             },
             HighTemperatureSimulationInputs,
             HighTemperatureSimulationOutputs,
-            control_topic_suffix=settings.mqtt_control_topic_suffix,
         ),
+        settings.mqtt_control_topic_suffix,
     ),
     "boilers": (
         boilers_path,
@@ -253,8 +253,8 @@ MODES: dict[Modes, tuple[str, CombinedModule]] = {
             {"boilers": BOILERS_MODULE_DESCRIPTION},
             BoilersSimulationInputs,
             BoilersSimulationOutputs,
-            control_topic_suffix=settings.mqtt_control_topic_suffix,
         ),
+        settings.mqtt_control_topic_suffix,
     ),
 }
 
@@ -708,7 +708,7 @@ class SimulationControls:
         all_modules = list(
             set(
                 module
-                for _fmu_path, nesting in MODES.values()
+                for _fmu_path, nesting, _control_topic_suffix in MODES.values()
                 for module in nesting.modules
             )
         )
@@ -734,7 +734,7 @@ class SimulationControls:
                 f"{self._topic_prefix}/{handler.subscribe_topic()}", qos=1
             )
 
-        fmu_path, modules = MODES[mode]
+        fmu_path, modules, control_topic_suffix = MODES[mode]
         simulation_inputs = INPUTS[mode]
 
         with self._simulation(fmu_path, modules, simulation_inputs) as simulation:
@@ -758,9 +758,10 @@ class SimulationControls:
                 self._control_client,
                 self._sensor_client,
                 self._topic_prefix,
-                modules.sensor_values_mqtt_mapping,
-                modules.control_values_mqtt_mapping,
-                modules.simulation_output_mqtt_mapping,
+                modules.sensor_values_clss,
+                modules.control_values_clss,
+                modules.simulation_outputs_cls,
+                control_topic_suffix,
             )
             runner = Runner(connector, control, modules.alarms())  # type: ignore
 

--- a/zero-thrs-control/src/thrs/cli/simulation_controls.py
+++ b/zero-thrs-control/src/thrs/cli/simulation_controls.py
@@ -725,7 +725,12 @@ class SimulationControls:
     ) -> Generator[Simulation, None, None]:
         with Fmu(fmu_path) as fmu:
             yield Simulation(
-                modules.io_mapping(), fmu, inputs, datetime.now(), timedelta(seconds=1)
+                modules.sensor_values_cls,
+                modules.simulation_outputs_cls,
+                fmu,
+                inputs,
+                datetime.now(),
+                timedelta(seconds=1),
             )
 
     async def run(self, mode: Modes):

--- a/zero-thrs-control/src/thrs/cli/simulation_controls.py
+++ b/zero-thrs-control/src/thrs/cli/simulation_controls.py
@@ -725,7 +725,7 @@ class SimulationControls:
     ) -> Generator[Simulation, None, None]:
         with Fmu(fmu_path) as fmu:
             yield Simulation(
-                modules.sensor_values_cls,
+                modules.sensor_values_clss,
                 modules.simulation_outputs_cls,
                 fmu,
                 inputs,

--- a/zero-thrs-control/src/thrs/control/modules/boilers.py
+++ b/zero-thrs-control/src/thrs/control/modules/boilers.py
@@ -13,7 +13,6 @@ from thrs.input_output.definitions.control import HeatPump, Pump, Valve
 from thrs.input_output.definitions.controllers import (
     PidControllerValues,
     TanksControllerValues,
-    TankState,
 )
 from thrs.input_output.definitions.units import (
     Celsius,
@@ -22,6 +21,7 @@ from thrs.input_output.definitions.units import (
     LMin,
     Ratio,
     Seconds,
+    TankState,
     Tuning,
 )
 from thrs.input_output.modules.boilers import BoilersControlValues, BoilersSensorValues

--- a/zero-thrs-control/src/thrs/graphql/pvt.py
+++ b/zero-thrs-control/src/thrs/graphql/pvt.py
@@ -1,6 +1,7 @@
 import strawberry
 
-from thrs.control.modules.pvt import PvtControlMode, PvtGroupControlMode, PvtParameters
+from thrs.control.modules.pvt import PvtControlMode, PvtParameters
+from thrs.control.modules.pvt_group import PvtGroupControlMode
 from thrs.graphql.base import (
     ControlModule,
     PvtMessaging,

--- a/zero-thrs-control/src/thrs/input_output/model_builder.py
+++ b/zero-thrs-control/src/thrs/input_output/model_builder.py
@@ -1,10 +1,12 @@
 from abc import ABC, abstractmethod
 from asyncio import Future, gather
+from collections.abc import Mapping
 from typing import Any
 
 from pydantic import TypeAdapter
 
 from thrs.input_output.base import CombinedValues, ThrsValues
+from thrs.orchestration.module import ModuleClassMap
 from thrs.utils.string import dash_to_snake
 
 
@@ -49,9 +51,9 @@ class PartialModelBuilder[T: ThrsValues](ModelBuilder[T]):
 
 
 class CombinedModelBuilder(ModelBuilder[CombinedValues]):
-    def __init__(self, clss: dict[str, type[ThrsValues]]):
-        self._model_builders: dict[str, ModelBuilder[ThrsValues]] = {
-            name: PartialModelBuilder(cls) for name, cls in clss.items()
+    def __init__(self, clss: ModuleClassMap):
+        self._model_builders: Mapping[str, ModelBuilder[ThrsValues]] = {
+            name: PartialModelBuilder(module_cls) for name, module_cls in clss.items()
         }
 
     def input(self, topic: str, json: str | bytes):

--- a/zero-thrs-control/src/thrs/orchestration/connector.py
+++ b/zero-thrs-control/src/thrs/orchestration/connector.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, Literal, Protocol
@@ -11,12 +12,119 @@ from thrs.input_output.base import (
     SimulationValues,
     ThrsValues,
 )
-from thrs.orchestration.module import CombinedModule, MqttMapping
+from thrs.input_output.model_builder import (
+    CombinedModelBuilder,
+    ModelBuilder,
+    PartialModelBuilder,
+)
 from thrs.simulation.fmu import Fmu
 from thrs.simulation.io_mapping import IoMapping
 from thrs.utils.string import hyphenize
 
 logger = logging.getLogger(__name__)
+
+
+class MqttMapping[M](Protocol):
+    """Mapping between a model and MQTT topics"""
+
+    def split_to_topics(self, model: M) -> dict[str, str]: ...
+
+    def builder(self) -> ModelBuilder[M]: ...
+
+    def has(self, topic: str) -> bool: ...
+
+    def subscribe_topic(self) -> str: ...
+
+
+class PartialMqttMapping[M: ThrsValues](MqttMapping[M]):
+    """MQTT mapping that maps each component in the model to a separate topic"""
+
+    def __init__(self, cls: type[M], topic_suffix: str | None = None):
+        self._cls = cls
+        self._topic_suffix = topic_suffix
+        self._keys = set(self._topic(key) for key in cls.model_fields.keys())
+
+    def split_to_topics(self, model: M) -> dict[str, str]:
+        return {
+            self._topic(key): getattr(model, key).model_dump_json(by_alias=True)
+            for key in type(model).model_fields.keys()
+        }
+
+    def _topic(self, key: str) -> str:
+        return (
+            f"{hyphenize(key)}/{self._topic_suffix}"
+            if self._topic_suffix
+            else hyphenize(key)
+        )
+
+    def has(self, topic: str) -> bool:
+        return topic in self._keys
+
+    def subscribe_topic(self) -> str:
+        return f"+/{self._topic_suffix}" if self._topic_suffix else "+"
+
+    def builder(self) -> ModelBuilder[M]:
+        return PartialModelBuilder(self._cls)
+
+
+class DirectMqttMapping[M: ThrsValues](MqttMapping[M]):
+    """MQTT mapping that maps the entire model to a single topic
+
+    Currently doesn't support builder"""
+
+    def __init__(self, cls: type[M], topic: str):
+        self._cls = cls
+        self._topic = topic
+
+    def split_to_topics(self, model: M) -> dict[str, str]:
+        return {self._topic: model.model_dump_json(by_alias=True)}
+
+    def has(self, topic: str) -> bool:
+        return topic == self._topic
+
+    def subscribe_topic(self) -> str:
+        return self._topic
+
+    def builder(self) -> ModelBuilder[M]:
+        raise NotImplementedError()
+
+
+class ModuleMqttMapping(MqttMapping[CombinedValues]):
+    """MQTT mapping for modules
+
+    Delegates to PartialMqttMapping for each sub-model."""
+
+    def __init__(
+        self, clss: Mapping[str, type[ThrsValues]], topic_suffix: str | None = None
+    ):
+        self._clss = dict(clss)
+        self._plain_mappings: dict[str, PartialMqttMapping] = {
+            name: PartialMqttMapping(cls, topic_suffix)
+            for name, cls in self._clss.items()
+        }
+        self._topic_suffix = topic_suffix
+
+    def split_to_topics(self, model: CombinedValues) -> dict[str, str]:
+        return {
+            f"{hyphenize(module)}/{key}": value
+            for module, model in model.values.items()
+            for key, value in self._plain_mappings[module]
+            .split_to_topics(model)
+            .items()
+        }
+
+    def builder(self) -> ModelBuilder[CombinedValues]:
+        return CombinedModelBuilder(self._clss)
+
+    def has(self, topic: str) -> bool:
+        module_name, key, *rest = topic.split("/")
+        mapping: PartialMqttMapping | Literal[False] = self._plain_mappings.get(
+            module_name, False
+        )
+        return mapping and mapping.has("/".join([key, *rest]))
+
+    def subscribe_topic(self) -> str:
+        return f"+/+/{self._topic_suffix}" if self._topic_suffix else "+/+"
 
 
 @dataclass
@@ -40,21 +148,23 @@ class MqttControlConnector(Connector[CombinedValues, CombinedValues]):
         self,
         mqtt_client: Client,
         topic_prefix: str,
-        module_nesting: CombinedModule,
+        sensor_values_mqtt_mapping: MqttMapping,
+        control_values_mqtt_mapping: MqttMapping,
         start_time: datetime | None = None,
     ):
         self._start_time = start_time or datetime.now()
         self._mqtt_client = mqtt_client
         self._topic_prefix = topic_prefix
-        self._module_nesting = module_nesting
+        self._sensor_values_mqtt_mapping = sensor_values_mqtt_mapping
+        self._control_values_mqtt_mapping = control_values_mqtt_mapping
 
         self._running = False
-        self._sensors_builder = module_nesting.sensor_values_mqtt_mapping.builder()
+        self._sensors_builder = self._sensor_values_mqtt_mapping.builder()
 
     async def _listen_to_sensors(self):
         async for message in self._mqtt_client.messages:
             topic = self._clean_topic(message.topic)
-            if not self._module_nesting.sensor_values_mqtt_mapping.has(topic):
+            if not self._sensor_values_mqtt_mapping.has(topic):
                 continue
             if not isinstance(message.payload, str | bytes):
                 raise ValueError(
@@ -81,13 +191,13 @@ class MqttControlConnector(Connector[CombinedValues, CombinedValues]):
         logging.debug("Publishing control values")
         await self._publish_by_mapping(
             self._mqtt_client,
-            self._module_nesting.control_values_mqtt_mapping,
+            self._control_values_mqtt_mapping,
             control_values,
         )
 
     async def start(self):
         await self._mqtt_client.subscribe(
-            f"{self._topic_prefix}/{self._module_nesting.sensor_values_mqtt_mapping.subscribe_topic()}",
+            f"{self._topic_prefix}/{self._sensor_values_mqtt_mapping.subscribe_topic()}",
             qos=1,
         )
 
@@ -127,12 +237,14 @@ class MqttSimulationConnector(Connector[CombinedValues, CombinedValues]):
         inner: "Simulation",
         mqtt_client: Client,
         topic_prefix: str,
-        module_nesting: CombinedModule,
+        sensor_values_mqtt_mapping: MqttMapping,
+        simulation_outputs_mqtt_mapping: MqttMapping,
     ):
         self._inner = inner
         self._mqtt_client = mqtt_client
         self._topic_prefix = topic_prefix
-        self._module_nesting = module_nesting
+        self._sensor_values_mqtt_mapping = sensor_values_mqtt_mapping
+        self._simulation_outputs_mqtt_mapping = simulation_outputs_mqtt_mapping
 
     async def _publish_by_mapping[T](
         self, client: Client, mapping: MqttMapping[T], value: T
@@ -169,7 +281,7 @@ class MqttSimulationConnector(Connector[CombinedValues, CombinedValues]):
         logging.debug("Publishing sensor values")
         await self._publish_by_mapping(
             self._mqtt_client,
-            self._module_nesting.sensor_values_mqtt_mapping,
+            self._sensor_values_mqtt_mapping,
             execution_result.sensor_values,
         )
 
@@ -188,7 +300,7 @@ class MqttSimulationConnector(Connector[CombinedValues, CombinedValues]):
             logging.debug("Publishing simulation output values")
             await self._publish_by_mapping(
                 self._mqtt_client,
-                self._module_nesting.simulation_output_mqtt_mapping,
+                self._simulation_outputs_mqtt_mapping,
                 simulation_result.simulation_outputs,
             )
 
@@ -212,18 +324,22 @@ class MqttConnector(Connector[CombinedValues, CombinedValues]):
         controller_client: Client,
         environment_client: Client,
         topic_prefix: str,
-        module_nesting: CombinedModule,
+        sensor_values_mqtt_mapping: MqttMapping,
+        control_values_mqtt_mapping: MqttMapping,
+        simulation_outputs_mqtt_mapping: MqttMapping,
     ):
         self._control_connector = MqttControlConnector(
             mqtt_client=controller_client,
             topic_prefix=topic_prefix,
-            module_nesting=module_nesting,
+            sensor_values_mqtt_mapping=sensor_values_mqtt_mapping,
+            control_values_mqtt_mapping=control_values_mqtt_mapping,
         )
         self._simulation_connector = MqttSimulationConnector(
             inner=inner,
             mqtt_client=environment_client,
             topic_prefix=topic_prefix,
-            module_nesting=module_nesting,
+            sensor_values_mqtt_mapping=sensor_values_mqtt_mapping,
+            simulation_outputs_mqtt_mapping=simulation_outputs_mqtt_mapping,
         )
 
     async def start(self):

--- a/zero-thrs-control/src/thrs/orchestration/connector.py
+++ b/zero-thrs-control/src/thrs/orchestration/connector.py
@@ -1,15 +1,12 @@
 import logging
 from collections.abc import Mapping
-from dataclasses import dataclass
-from datetime import datetime, timedelta
-from typing import Any, Literal, Protocol
+from datetime import datetime
+from typing import Literal, Protocol
 
 from aiomqtt import Client, Topic
 
 from thrs.input_output.base import (
     CombinedValues,
-    SimulationInputs,
-    SimulationValues,
     ThrsValues,
 )
 from thrs.input_output.model_builder import (
@@ -18,8 +15,7 @@ from thrs.input_output.model_builder import (
     PartialModelBuilder,
 )
 from thrs.orchestration.module import ModuleClassMap
-from thrs.simulation.fmu import Fmu
-from thrs.simulation.io_mapping import CombinedIoMapping, IoMapping, ThrsModelIoMapping
+from thrs.orchestration.simulation import ExecutionResult, Simulation, SimulationResult
 from thrs.utils.string import hyphenize
 
 logger = logging.getLogger(__name__)
@@ -124,12 +120,6 @@ class ModuleMqttMapping(MqttMapping[CombinedValues]):
 
     def subscribe_topic(self) -> str:
         return f"+/+/{self._topic_suffix}" if self._topic_suffix else "+/+"
-
-
-@dataclass
-class ExecutionResult[S]:
-    timestamp: datetime
-    sensor_values: S
 
 
 class Connector[S, C](Protocol):
@@ -367,116 +357,3 @@ class MqttConnector(Connector[CombinedValues, CombinedValues]):
 
     def time(self) -> datetime:
         return self._simulation_connector.time()
-
-
-# TODO: Move below classes to another file
-@dataclass
-class SimulationResult[
-    S,
-    C,
-    I: SimulationInputs,
-    O: SimulationValues,
-](ExecutionResult[S]):
-    control_values: C
-    simulation_outputs: O
-    simulation_inputs: I
-    raw: dict[str, Any]
-    fmu: Fmu
-
-    def read_fmu_value(self, name: str) -> Any:
-        variable = next(
-            (
-                variable
-                for variable in self.fmu._model_description.modelVariables
-                if name == variable.name
-            ),
-            None,
-        )
-        if variable is None:
-            raise ValueError(f"Variable '{name}' not found in FMU model.")
-        return self.fmu._fmu_instance.getReal([variable.valueReference])[0]  # type: ignore
-
-    def find_fmu_variables(
-        self, name: str, match: Literal["include", "startswith"] = "include"
-    ) -> list[Any]:
-        return [
-            variable
-            for variable in self.fmu._model_description.modelVariables
-            if (
-                name in variable.name
-                if match == "include"
-                else variable.name.startswith(name)
-            )
-        ]
-
-    def summarize_fmu_values(self, name: str) -> dict[str, Any]:
-        variables = self.find_fmu_variables(f"{name}.summary", match="startswith")
-        return {
-            variable.name: self.read_fmu_value(variable.name) for variable in variables
-        }
-
-
-class Simulation[
-    S,
-    C,
-    I: SimulationInputs,
-    O: SimulationValues,
-]:
-    def __init__(
-        self,
-        sensor_values_cls: type[ThrsValues],
-        simulation_outputs_cls: type[SimulationValues],
-        fmu: Fmu,
-        simulation_inputs: I,
-        start_time: datetime,
-        tick_duration: timedelta,
-    ):
-        self._start_time = start_time
-        self._ticks = 0
-        self._tick_duration = tick_duration
-        self._simulation_inputs = simulation_inputs
-        self._fmu = fmu
-        self._io_mapping: IoMapping = (
-            CombinedIoMapping(sensor_values_cls, simulation_outputs_cls)  # type: ignore
-            if sensor_values_cls.__name__ == "CombinedSensorValues"  # type: ignore # TODO refactor this away
-            else ThrsModelIoMapping(sensor_values_cls, simulation_outputs_cls)
-        )
-
-    async def start(self):
-        pass
-
-    @property
-    def start_time(self) -> datetime:
-        return self._start_time
-
-    @property
-    def tick_duration(self) -> timedelta:
-        return self._tick_duration
-
-    def time(self):
-        return self._start_time + self._ticks * self._tick_duration
-
-    async def tick(self, control_values: C) -> SimulationResult[S, C, I, O]:
-        logging.debug("Running simulation tick")
-        time = self.time()
-
-        simulation_inputs = self._simulation_inputs.get_values_at_time(time)
-        fmu_inputs = self._io_mapping.generate_inputs(control_values, simulation_inputs)
-        fmu_outputs = self._fmu.tick(fmu_inputs, self._tick_duration)
-        sensor_values, simulation_outputs, raw = self._io_mapping.construct_outputs(
-            fmu_inputs, fmu_outputs, simulation_inputs, time + self._tick_duration
-        )
-
-        self._ticks += 1
-        return SimulationResult(
-            timestamp=time,
-            sensor_values=sensor_values,
-            control_values=control_values,
-            simulation_outputs=simulation_outputs,
-            simulation_inputs=simulation_inputs,
-            raw=raw,
-            fmu=self._fmu,
-        )
-
-    def update_simulation_inputs(self, simulation_inputs: I):
-        self._simulation_inputs = simulation_inputs

--- a/zero-thrs-control/src/thrs/orchestration/connector.py
+++ b/zero-thrs-control/src/thrs/orchestration/connector.py
@@ -17,6 +17,7 @@ from thrs.input_output.model_builder import (
     ModelBuilder,
     PartialModelBuilder,
 )
+from thrs.orchestration.module import ModuleClassMap
 from thrs.simulation.fmu import Fmu
 from thrs.simulation.io_mapping import IoMapping
 from thrs.utils.string import hyphenize
@@ -94,13 +95,11 @@ class ModuleMqttMapping(MqttMapping[CombinedValues]):
 
     Delegates to PartialMqttMapping for each sub-model."""
 
-    def __init__(
-        self, clss: Mapping[str, type[ThrsValues]], topic_suffix: str | None = None
-    ):
-        self._clss = dict(clss)
-        self._plain_mappings: dict[str, PartialMqttMapping] = {
-            name: PartialMqttMapping(cls, topic_suffix)
-            for name, cls in self._clss.items()
+    def __init__(self, clss: ModuleClassMap, topic_suffix: str | None = None):
+        self._clss = clss
+        self._plain_mappings: Mapping[str, PartialMqttMapping] = {
+            name: PartialMqttMapping(module_cls, topic_suffix)
+            for name, module_cls in clss.items()
         }
         self._topic_suffix = topic_suffix
 
@@ -148,15 +147,18 @@ class MqttControlConnector(Connector[CombinedValues, CombinedValues]):
         self,
         mqtt_client: Client,
         topic_prefix: str,
-        sensor_values_mqtt_mapping: MqttMapping,
-        control_values_mqtt_mapping: MqttMapping,
+        sensor_values_clss: ModuleClassMap,
+        control_values_clss: ModuleClassMap,
+        control_topic_suffix: str | None = None,
         start_time: datetime | None = None,
     ):
         self._start_time = start_time or datetime.now()
         self._mqtt_client = mqtt_client
         self._topic_prefix = topic_prefix
-        self._sensor_values_mqtt_mapping = sensor_values_mqtt_mapping
-        self._control_values_mqtt_mapping = control_values_mqtt_mapping
+        self._sensor_values_mqtt_mapping = ModuleMqttMapping(sensor_values_clss)
+        self._control_values_mqtt_mapping = ModuleMqttMapping(
+            control_values_clss, control_topic_suffix
+        )
 
         self._running = False
         self._sensors_builder = self._sensor_values_mqtt_mapping.builder()
@@ -237,14 +239,16 @@ class MqttSimulationConnector(Connector[CombinedValues, CombinedValues]):
         inner: "Simulation",
         mqtt_client: Client,
         topic_prefix: str,
-        sensor_values_mqtt_mapping: MqttMapping,
-        simulation_outputs_mqtt_mapping: MqttMapping,
+        sensor_values_clss: ModuleClassMap,
+        simulation_outputs_cls: type[ThrsValues],
     ):
         self._inner = inner
         self._mqtt_client = mqtt_client
         self._topic_prefix = topic_prefix
-        self._sensor_values_mqtt_mapping = sensor_values_mqtt_mapping
-        self._simulation_outputs_mqtt_mapping = simulation_outputs_mqtt_mapping
+        self._sensor_values_mqtt_mapping = ModuleMqttMapping(sensor_values_clss)
+        self._simulation_outputs_mqtt_mapping = DirectMqttMapping(
+            simulation_outputs_cls, "simulation/outputs"
+        )
 
     async def _publish_by_mapping[T](
         self, client: Client, mapping: MqttMapping[T], value: T
@@ -324,22 +328,24 @@ class MqttConnector(Connector[CombinedValues, CombinedValues]):
         controller_client: Client,
         environment_client: Client,
         topic_prefix: str,
-        sensor_values_mqtt_mapping: MqttMapping,
-        control_values_mqtt_mapping: MqttMapping,
-        simulation_outputs_mqtt_mapping: MqttMapping,
+        sensor_values_clss: ModuleClassMap,
+        control_values_clss: ModuleClassMap,
+        simulation_outputs_cls: type[ThrsValues],
+        control_topic_suffix: str | None = None,
     ):
         self._control_connector = MqttControlConnector(
             mqtt_client=controller_client,
             topic_prefix=topic_prefix,
-            sensor_values_mqtt_mapping=sensor_values_mqtt_mapping,
-            control_values_mqtt_mapping=control_values_mqtt_mapping,
+            sensor_values_clss=sensor_values_clss,
+            control_values_clss=control_values_clss,
+            control_topic_suffix=control_topic_suffix,
         )
         self._simulation_connector = MqttSimulationConnector(
             inner=inner,
             mqtt_client=environment_client,
             topic_prefix=topic_prefix,
-            sensor_values_mqtt_mapping=sensor_values_mqtt_mapping,
-            simulation_outputs_mqtt_mapping=simulation_outputs_mqtt_mapping,
+            sensor_values_clss=sensor_values_clss,
+            simulation_outputs_cls=simulation_outputs_cls,
         )
 
     async def start(self):

--- a/zero-thrs-control/src/thrs/orchestration/connector.py
+++ b/zero-thrs-control/src/thrs/orchestration/connector.py
@@ -124,7 +124,7 @@ class ModuleMqttMapping(MqttMapping[CombinedValues]):
 
 class Connector[S, C](Protocol):
     async def start(self): ...
-    async def tick(self, control_values: C) -> ExecutionResult[S]: ...
+    async def transceive(self, control_values: C) -> ExecutionResult[S]: ...
 
     @property
     def start_time(self) -> datetime: ...
@@ -200,7 +200,7 @@ class MqttControlConnector(Connector[CombinedValues, CombinedValues]):
         finally:
             self._running = False
 
-    async def tick(
+    async def transceive(
         self, control_values: CombinedValues
     ) -> ExecutionResult[CombinedValues]:
         if not self._running:
@@ -282,7 +282,7 @@ class MqttSimulationConnector(Connector[CombinedValues, CombinedValues]):
     async def start(self):
         await self._inner.start()
 
-    async def tick(
+    async def transceive(
         self, control_values: CombinedValues
     ) -> ExecutionResult[CombinedValues]:
         logging.debug("Executing simulation")
@@ -345,11 +345,11 @@ class MqttConnector(Connector[CombinedValues, CombinedValues]):
     async def run(self):
         await self._control_connector.run()
 
-    async def tick(
+    async def transceive(
         self, control_values: CombinedValues
     ) -> ExecutionResult[CombinedValues]:
-        await self._control_connector.tick(control_values)
-        return await self._simulation_connector.tick(control_values)
+        await self._control_connector.transceive(control_values)
+        return await self._simulation_connector.transceive(control_values)
 
     @property
     def start_time(self) -> datetime:

--- a/zero-thrs-control/src/thrs/orchestration/connector.py
+++ b/zero-thrs-control/src/thrs/orchestration/connector.py
@@ -19,7 +19,7 @@ from thrs.input_output.model_builder import (
 )
 from thrs.orchestration.module import ModuleClassMap
 from thrs.simulation.fmu import Fmu
-from thrs.simulation.io_mapping import IoMapping
+from thrs.simulation.io_mapping import CombinedIoMapping, IoMapping, ThrsModelIoMapping
 from thrs.utils.string import hyphenize
 
 logger = logging.getLogger(__name__)
@@ -424,7 +424,8 @@ class Simulation[
 ]:
     def __init__(
         self,
-        io_mapping: IoMapping[S, C, I, O],
+        sensor_values_cls: type[ThrsValues],
+        simulation_outputs_cls: type[SimulationValues],
         fmu: Fmu,
         simulation_inputs: I,
         start_time: datetime,
@@ -435,7 +436,11 @@ class Simulation[
         self._tick_duration = tick_duration
         self._simulation_inputs = simulation_inputs
         self._fmu = fmu
-        self._io_mapping = io_mapping
+        self._io_mapping: IoMapping = (
+            CombinedIoMapping(sensor_values_cls, simulation_outputs_cls)  # type: ignore
+            if sensor_values_cls.__name__ == "CombinedSensorValues"  # type: ignore # TODO refactor this away
+            else ThrsModelIoMapping(sensor_values_cls, simulation_outputs_cls)
+        )
 
     async def start(self):
         pass

--- a/zero-thrs-control/src/thrs/orchestration/module.py
+++ b/zero-thrs-control/src/thrs/orchestration/module.py
@@ -12,7 +12,6 @@ from thrs.input_output.base import (
     SimulationValues,
     ThrsValues,
 )
-from thrs.simulation.io_mapping import CombinedIoMapping, IoMapping
 
 type ModuleClassMap = Mapping[str, type[ThrsValues]]
 
@@ -141,12 +140,6 @@ class CombinedModule[I: SimulationInputs, O: SimulationValues]:
         }
         self._simulation_inputs_cls = simulation_inputs_cls
         self._simulation_outputs_cls = simulation_outputs_cls
-
-    def io_mapping(self) -> IoMapping:
-        return CombinedIoMapping(
-            {module: desc.sensor_values_cls for module, desc in self._modules.items()},
-            self._simulation_outputs_cls,
-        )
 
     @property
     def modules(self) -> list[str]:

--- a/zero-thrs-control/src/thrs/orchestration/module.py
+++ b/zero-thrs-control/src/thrs/orchestration/module.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Callable, Literal, Mapping, Protocol
+from typing import Callable, Mapping
 
 from thrs.classes.control import Control, ControlResult
 from thrs.control.base import ModuleDescription
@@ -12,116 +12,12 @@ from thrs.input_output.base import (
     SimulationValues,
     ThrsValues,
 )
-from thrs.input_output.model_builder import (
-    CombinedModelBuilder,
-    ModelBuilder,
-    PartialModelBuilder,
+from thrs.orchestration.connector import (
+    DirectMqttMapping,
+    ModuleMqttMapping,
+    MqttMapping,
 )
 from thrs.simulation.io_mapping import CombinedIoMapping, IoMapping
-from thrs.utils.string import hyphenize
-
-
-class MqttMapping[M](Protocol):
-    """Mapping between a model and MQTT topics"""
-
-    def split_to_topics(self, model: M) -> dict[str, str]: ...
-
-    def builder(self) -> ModelBuilder[M]: ...
-
-    def has(self, topic: str) -> bool: ...
-
-    def subscribe_topic(self) -> str: ...
-
-
-class PartialMqttMapping[M: ThrsValues](MqttMapping[M]):
-    """MQTT mapping that maps each component in the model to a separate topic"""
-
-    def __init__(self, cls: type[M], topic_suffix: str | None = None):
-        self._cls = cls
-        self._topic_suffix = topic_suffix
-        self._keys = set(self._topic(key) for key in cls.model_fields.keys())
-
-    def split_to_topics(self, model: M) -> dict[str, str]:
-        return {
-            self._topic(key): getattr(model, key).model_dump_json(by_alias=True)
-            for key in type(model).model_fields.keys()
-        }
-
-    def _topic(self, key: str) -> str:
-        return (
-            f"{hyphenize(key)}/{self._topic_suffix}"
-            if self._topic_suffix
-            else hyphenize(key)
-        )
-
-    def has(self, topic: str) -> bool:
-        return topic in self._keys
-
-    def subscribe_topic(self) -> str:
-        return f"+/{self._topic_suffix}" if self._topic_suffix else "+"
-
-    def builder(self) -> ModelBuilder[M]:
-        return PartialModelBuilder(self._cls)
-
-
-class DirectMqttMapping[M: ThrsValues](MqttMapping[M]):
-    """MQTT mapping that maps the entire model to a single topic
-
-    Currently doesn't support builder"""
-
-    def __init__(self, cls: type[M], topic: str):
-        self._cls = cls
-        self._topic = topic
-
-    def split_to_topics(self, model: M) -> dict[str, str]:
-        return {self._topic: model.model_dump_json(by_alias=True)}
-
-    def has(self, topic: str) -> bool:
-        return topic == self._topic
-
-    def subscribe_topic(self) -> str:
-        return self._topic
-
-    def builder(self) -> ModelBuilder[M]:
-        raise NotImplementedError()
-
-
-class ModuleMqttMapping(MqttMapping[CombinedValues]):
-    """MQTT mapping for modules
-
-    Delegates to PartialMqttMapping for each sub-model."""
-
-    def __init__(
-        self, clss: Mapping[str, type[ThrsValues]], topic_suffix: str | None = None
-    ):
-        self._clss = dict(clss)
-        self._plain_mappings: dict[str, PartialMqttMapping] = {
-            name: PartialMqttMapping(cls, topic_suffix)
-            for name, cls in self._clss.items()
-        }
-        self._topic_suffix = topic_suffix
-
-    def split_to_topics(self, model: CombinedValues) -> dict[str, str]:
-        return {
-            f"{hyphenize(module)}/{key}": value
-            for module, model in model.values.items()
-            for key, value in self._plain_mappings[module]
-            .split_to_topics(model)
-            .items()
-        }
-
-    def builder(self) -> ModelBuilder[CombinedValues]:
-        return CombinedModelBuilder(self._clss)
-
-    def has(self, topic: str) -> bool:
-        module_name, key, *rest = topic.split("/")
-        mapping: PartialMqttMapping | Literal[False] = self._plain_mappings.get(
-            module_name, False
-        )
-        return mapping and mapping.has("/".join([key, *rest]))
-
-    def subscribe_topic(self) -> str:
-        return f"+/+/{self._topic_suffix}" if self._topic_suffix else "+/+"
 
 
 class CombinedControl(
@@ -256,7 +152,7 @@ class CombinedModule[I: SimulationInputs, O: SimulationValues]:
 
     def io_mapping(self) -> IoMapping:
         return CombinedIoMapping(
-            {name: module.sensor_values_cls for name, module in self._modules.items()},
+            {module: desc.sensor_values_cls for module, desc in self._modules.items()},
             self._simulation_outputs_cls,
         )
 

--- a/zero-thrs-control/src/thrs/orchestration/module.py
+++ b/zero-thrs-control/src/thrs/orchestration/module.py
@@ -12,12 +12,9 @@ from thrs.input_output.base import (
     SimulationValues,
     ThrsValues,
 )
-from thrs.orchestration.connector import (
-    DirectMqttMapping,
-    ModuleMqttMapping,
-    MqttMapping,
-)
 from thrs.simulation.io_mapping import CombinedIoMapping, IoMapping
+
+type ModuleClassMap = Mapping[str, type[ThrsValues]]
 
 
 class CombinedControl(
@@ -134,21 +131,16 @@ class CombinedModule[I: SimulationInputs, O: SimulationValues]:
         modules: dict[str, ModuleDescription],
         simulation_inputs_cls: type[I],
         simulation_outputs_cls: type[O],
-        control_topic_suffix: str | None = None,
     ):
         self._modules = modules
-        self._sensor_mqtt_mapping = ModuleMqttMapping(
-            {module: desc.sensor_values_cls for module, desc in modules.items()}
-        )
-        self._control_mqtt_mapping = ModuleMqttMapping(
-            {module: desc.control_values_cls for module, desc in modules.items()},
-            topic_suffix=control_topic_suffix,
-        )
+        self.sensor_values_clss: ModuleClassMap = {
+            module: desc.sensor_values_cls for module, desc in modules.items()
+        }
+        self.control_values_clss: ModuleClassMap = {
+            module: desc.control_values_cls for module, desc in modules.items()
+        }
         self._simulation_inputs_cls = simulation_inputs_cls
         self._simulation_outputs_cls = simulation_outputs_cls
-        self._simulation_output_mapping = DirectMqttMapping(
-            simulation_outputs_cls, topic="simulation/outputs"
-        )
 
     def io_mapping(self) -> IoMapping:
         return CombinedIoMapping(
@@ -159,18 +151,6 @@ class CombinedModule[I: SimulationInputs, O: SimulationValues]:
     @property
     def modules(self) -> list[str]:
         return list(self._modules.keys())
-
-    @property
-    def sensor_values_mqtt_mapping(self) -> MqttMapping[CombinedValues]:
-        return self._sensor_mqtt_mapping
-
-    @property
-    def control_values_mqtt_mapping(self) -> MqttMapping[CombinedValues]:
-        return self._control_mqtt_mapping
-
-    @property
-    def simulation_output_mqtt_mapping(self) -> MqttMapping[O]:
-        return self._simulation_output_mapping
 
     @property
     def simulation_inputs_cls(self) -> type[I]:

--- a/zero-thrs-control/src/thrs/orchestration/runner.py
+++ b/zero-thrs-control/src/thrs/orchestration/runner.py
@@ -57,7 +57,7 @@ class ModuleSimulatorModel:
     def simulation(self):
         with Fmu(self.fmu_path) as fmu:
             yield Simulation(
-                self.module.sensor_values_cls,
+                self.module.sensor_values_clss,
                 self.module.simulation_outputs_cls,
                 fmu,
                 self.simulation_inputs,

--- a/zero-thrs-control/src/thrs/orchestration/runner.py
+++ b/zero-thrs-control/src/thrs/orchestration/runner.py
@@ -17,7 +17,7 @@ from thrs.orchestration.connector import Connector, ExecutionResult
 from thrs.orchestration.module import CombinedModule
 from thrs.orchestration.simulation import Simulation, SimulationResult
 from thrs.simulation.fmu import Fmu
-from thrs.simulation.io_mapping import ThrsModelIoMapping, flatten_model_values
+from thrs.simulation.io_mapping import flatten_model_values
 
 
 @dataclass
@@ -36,10 +36,8 @@ class SimulatorModel:
     def simulation(self):
         with Fmu(self.fmu_path) as fmu:
             yield Simulation(
-                ThrsModelIoMapping(
-                    self.sensor_values_cls,
-                    self.simulation_outputs_cls,
-                ),
+                self.sensor_values_cls,
+                self.simulation_outputs_cls,
                 fmu,
                 self.simulation_inputs,
                 self.start_time,
@@ -59,7 +57,8 @@ class ModuleSimulatorModel:
     def simulation(self):
         with Fmu(self.fmu_path) as fmu:
             yield Simulation(
-                self.module.io_mapping(),
+                self.module.sensor_values_cls,
+                self.module.simulation_outputs_cls,
                 fmu,
                 self.simulation_inputs,
                 self.start_time,

--- a/zero-thrs-control/src/thrs/orchestration/runner.py
+++ b/zero-thrs-control/src/thrs/orchestration/runner.py
@@ -101,7 +101,7 @@ class Runner[S: ThrsValues, C: ThrsValues, P: ThrsValues, M: ThrsValues]:
     async def run(self, n_ticks: int, collector: Collector | None = None) -> None:
         result = None
         for _ in range(n_ticks):
-            result = await self._connector.tick(self._control_values)
+            result = await self._connector.transceive(self._control_values)
             if isinstance(result, SimulationResult) and collector is not None:
                 collector.collect(
                     {

--- a/zero-thrs-control/src/thrs/orchestration/simulation.py
+++ b/zero-thrs-control/src/thrs/orchestration/simulation.py
@@ -1,4 +1,129 @@
-from thrs.orchestration.connector import Simulation, SimulationResult
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Literal
 
-# Reimport so we can already use them from the right position
-__all__ = ["Simulation", "SimulationResult"]
+from thrs.input_output.base import SimulationInputs, SimulationValues, ThrsValues
+from thrs.orchestration.module import ModuleClassMap
+from thrs.simulation.fmu import Fmu
+from thrs.simulation.io_mapping import CombinedIoMapping, IoMapping, ThrsModelIoMapping
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ExecutionResult[S]:
+    timestamp: datetime
+    sensor_values: S
+
+
+@dataclass
+class SimulationResult[
+    S,
+    C,
+    I: SimulationInputs,
+    O: SimulationValues,
+](ExecutionResult[S]):
+    control_values: C
+    simulation_outputs: O
+    simulation_inputs: I
+    raw: dict[str, Any]
+    fmu: Fmu
+
+    def read_fmu_value(self, name: str) -> Any:
+        variable = next(
+            (
+                variable
+                for variable in self.fmu._model_description.modelVariables
+                if name == variable.name
+            ),
+            None,
+        )
+        if variable is None:
+            raise ValueError(f"Variable '{name}' not found in FMU model.")
+        return self.fmu._fmu_instance.getReal([variable.valueReference])[0]  # type: ignore
+
+    def find_fmu_variables(
+        self, name: str, match: Literal["include", "startswith"] = "include"
+    ) -> list[Any]:
+        return [
+            variable
+            for variable in self.fmu._model_description.modelVariables
+            if (
+                name in variable.name
+                if match == "include"
+                else variable.name.startswith(name)
+            )
+        ]
+
+    def summarize_fmu_values(self, name: str) -> dict[str, Any]:
+        variables = self.find_fmu_variables(f"{name}.summary", match="startswith")
+        return {
+            variable.name: self.read_fmu_value(variable.name) for variable in variables
+        }
+
+
+class Simulation[
+    S,
+    C,
+    I: SimulationInputs,
+    O: SimulationValues,
+]:
+    def __init__(
+        self,
+        sensor_values_clss: ModuleClassMap | type[ThrsValues],
+        simulation_outputs_cls: type[SimulationValues],
+        fmu: Fmu,
+        simulation_inputs: I,
+        start_time: datetime,
+        tick_duration: timedelta,
+    ):
+        self._start_time = start_time
+        self._ticks = 0
+        self._tick_duration = tick_duration
+        self._simulation_inputs = simulation_inputs
+        self._fmu = fmu
+        self._io_mapping: IoMapping = (
+            CombinedIoMapping(sensor_values_clss, simulation_outputs_cls)  # type: ignore
+            if isinstance(sensor_values_clss, dict)
+            else ThrsModelIoMapping(sensor_values_clss, simulation_outputs_cls)  # type: ignore
+        )
+
+    async def start(self):
+        pass
+
+    @property
+    def start_time(self) -> datetime:
+        return self._start_time
+
+    @property
+    def tick_duration(self) -> timedelta:
+        return self._tick_duration
+
+    def time(self):
+        return self._start_time + self._ticks * self._tick_duration
+
+    async def tick(self, control_values: C) -> SimulationResult[S, C, I, O]:
+        logging.debug("Running simulation tick")
+        time = self.time()
+
+        simulation_inputs = self._simulation_inputs.get_values_at_time(time)
+        fmu_inputs = self._io_mapping.generate_inputs(control_values, simulation_inputs)
+        fmu_outputs = self._fmu.tick(fmu_inputs, self._tick_duration)
+        sensor_values, simulation_outputs, raw = self._io_mapping.construct_outputs(
+            fmu_inputs, fmu_outputs, simulation_inputs, time + self._tick_duration
+        )
+
+        self._ticks += 1
+        return SimulationResult(
+            timestamp=time,
+            sensor_values=sensor_values,
+            control_values=control_values,
+            simulation_outputs=simulation_outputs,
+            simulation_inputs=simulation_inputs,
+            raw=raw,
+            fmu=self._fmu,
+        )
+
+    def update_simulation_inputs(self, simulation_inputs: I):
+        self._simulation_inputs = simulation_inputs

--- a/zero-thrs-control/src/thrs/simulation/io_mapping.py
+++ b/zero-thrs-control/src/thrs/simulation/io_mapping.py
@@ -18,6 +18,7 @@ from thrs.input_output.fmu_mapping import (
     extract_non_fmu_values,
     included_in_fmu,
 )
+from thrs.orchestration.module import ModuleClassMap
 
 
 def flatten_model_values(model: ThrsValues, fmu_only: bool) -> dict[str, float]:
@@ -76,14 +77,10 @@ class CombinedIoMapping[I: SimulationInputs, O: SimulationValues](
 ):
     def __init__(
         self,
-        sensor_values_cls: type[ThrsValues],
+        sensor_values_clss: ModuleClassMap,
         simulation_outputs_cls: type[O],
     ):
-        self._sensor_values_clss = {
-            module: field.annotation
-            for module, field in sensor_values_cls.model_fields.items()
-            if field.annotation and issubclass(field.annotation, ThrsValues)
-        }
+        self._sensor_values_clss = sensor_values_clss
         self._simulation_outputs_cls = simulation_outputs_cls
 
     def generate_inputs(
@@ -147,16 +144,13 @@ class ThrsModelIoMapping[
         sensor_values_cls: type[S],
         simulation_outputs_cls: type[O],
     ):
-        class CombinedSensorValues(ThrsValues):
-            values: sensor_values_cls  # type: ignore  #TODO refactor
-
-        self._sub = CombinedIoMapping(CombinedSensorValues, simulation_outputs_cls)
+        self._sub = CombinedIoMapping({"": sensor_values_cls}, simulation_outputs_cls)
 
     def generate_inputs(
         self, control_values: C, simulation_inputs: I
     ) -> dict[str, Any]:
         return self._sub.generate_inputs(
-            CombinedValues({"values": control_values}), simulation_inputs
+            CombinedValues({"": control_values}), simulation_inputs
         )
 
     def construct_outputs(
@@ -169,4 +163,4 @@ class ThrsModelIoMapping[
         sensor_values, outputs, raw = self._sub.construct_outputs(
             fmu_inputs, fmu_outputs, simulation_inputs, time
         )
-        return cast(S, sensor_values.values["values"]), outputs, raw
+        return cast(S, sensor_values.values[""]), outputs, raw

--- a/zero-thrs-control/src/thrs/simulation/io_mapping.py
+++ b/zero-thrs-control/src/thrs/simulation/io_mapping.py
@@ -76,10 +76,14 @@ class CombinedIoMapping[I: SimulationInputs, O: SimulationValues](
 ):
     def __init__(
         self,
-        sensor_values_clss: dict[str, type[ThrsValues]],
+        sensor_values_cls: type[ThrsValues],
         simulation_outputs_cls: type[O],
     ):
-        self._sensor_values_clss = sensor_values_clss
+        self._sensor_values_clss = {
+            module: field.annotation
+            for module, field in sensor_values_cls.model_fields.items()
+            if field.annotation and issubclass(field.annotation, ThrsValues)
+        }
         self._simulation_outputs_cls = simulation_outputs_cls
 
     def generate_inputs(
@@ -143,13 +147,16 @@ class ThrsModelIoMapping[
         sensor_values_cls: type[S],
         simulation_outputs_cls: type[O],
     ):
-        self._sub = CombinedIoMapping({"": sensor_values_cls}, simulation_outputs_cls)
+        class CombinedSensorValues(ThrsValues):
+            values: sensor_values_cls  # type: ignore  #TODO refactor
+
+        self._sub = CombinedIoMapping(CombinedSensorValues, simulation_outputs_cls)
 
     def generate_inputs(
         self, control_values: C, simulation_inputs: I
     ) -> dict[str, Any]:
         return self._sub.generate_inputs(
-            CombinedValues({"": control_values}), simulation_inputs
+            CombinedValues({"values": control_values}), simulation_inputs
         )
 
     def construct_outputs(
@@ -162,4 +169,4 @@ class ThrsModelIoMapping[
         sensor_values, outputs, raw = self._sub.construct_outputs(
             fmu_inputs, fmu_outputs, simulation_inputs, time
         )
-        return cast(S, sensor_values.values[""]), outputs, raw
+        return cast(S, sensor_values.values["values"]), outputs, raw

--- a/zero-thrs-control/tests/control/conftest.py
+++ b/zero-thrs-control/tests/control/conftest.py
@@ -20,7 +20,6 @@ from thrs.input_output.modules.thrusters import (
 )
 from thrs.orchestration.simulation import Simulation
 from thrs.simulation.fmu import Fmu
-from thrs.simulation.io_mapping import ThrsModelIoMapping
 from thrs.simulation.models.fmu_paths import thrusters_path
 
 
@@ -42,20 +41,17 @@ def simulation_inputs():
 
 
 @fixture
-def io_mapping():
-    return ThrsModelIoMapping(
-        ThrustersSensorValues,
-        ThrustersSimulationOutputs,
-    )
-
-
-@fixture
 def simulation(
-    io_mapping, simulation_inputs: ThrustersSimulationInputs
+    simulation_inputs: ThrustersSimulationInputs,
 ) -> Generator[ThrustersSimulation, None, None]:
     with Fmu(thrusters_path) as fmu:
         yield Simulation(
-            io_mapping, fmu, simulation_inputs, datetime.now(), timedelta(seconds=1)
+            ThrustersSensorValues,
+            ThrustersSimulationOutputs,
+            fmu,
+            simulation_inputs,
+            datetime.now(),
+            timedelta(seconds=1),
         )
 
 

--- a/zero-thrs-control/tests/modules/boilers/conftest.py
+++ b/zero-thrs-control/tests/modules/boilers/conftest.py
@@ -27,7 +27,6 @@ from thrs.input_output.modules.boilers import (
 from thrs.orchestration.runner import Runner
 from thrs.orchestration.simulation import Simulation
 from thrs.simulation.fmu import Fmu
-from thrs.simulation.io_mapping import ThrsModelIoMapping
 from thrs.simulation.models.fmu_paths import boilers_path
 
 
@@ -63,18 +62,15 @@ def simulation_inputs():
 
 
 @fixture
-def io_mapping():
-    return ThrsModelIoMapping(
-        BoilersSensorValues,
-        BoilersSimulationOutputs,
-    )
-
-
-@fixture
-def simulation(io_mapping, simulation_inputs):
+def simulation(simulation_inputs):
     with Fmu(boilers_path) as fmu:
         yield Simulation(
-            io_mapping, fmu, simulation_inputs, datetime.now(), timedelta(seconds=1)
+            BoilersSensorValues,
+            BoilersSimulationOutputs,
+            fmu,
+            simulation_inputs,
+            datetime.now(),
+            timedelta(seconds=1),
         )
 
 

--- a/zero-thrs-control/tests/modules/boilers/conftest.py
+++ b/zero-thrs-control/tests/modules/boilers/conftest.py
@@ -95,6 +95,7 @@ def runner(
 ) -> Runner[
     BoilersSensorValues, BoilersControlValues, BoilersParameters, BoilersControlMode
 ]:
+    simulation.transceive = simulation.tick  # type: ignore # TODO: Make this make sense
     return Runner(simulation, control, alarms)
 
 

--- a/zero-thrs-control/tests/modules/consumers/conftest.py
+++ b/zero-thrs-control/tests/modules/consumers/conftest.py
@@ -12,7 +12,6 @@ from thrs.input_output.modules.consumers import (
 )
 from thrs.orchestration.simulation import Simulation
 from thrs.simulation.fmu import Fmu
-from thrs.simulation.io_mapping import ThrsModelIoMapping
 from thrs.simulation.models.fmu_paths import consumers_path
 
 
@@ -49,16 +48,13 @@ def simulation_inputs():
 
 
 @fixture
-def io_mapping():
-    return ThrsModelIoMapping(
-        ConsumersSensorValues,
-        ConsumersSimulationOutputs,
-    )
-
-
-@fixture
-def simulation(io_mapping, simulation_inputs):
+def simulation(simulation_inputs):
     with Fmu(consumers_path) as fmu:
         yield Simulation(
-            io_mapping, fmu, simulation_inputs, datetime.now(), timedelta(seconds=1)
+            ConsumersSensorValues,
+            ConsumersSimulationOutputs,
+            fmu,
+            simulation_inputs,
+            datetime.now(),
+            timedelta(seconds=1),
         )

--- a/zero-thrs-control/tests/modules/consumers/test_simulation.py
+++ b/zero-thrs-control/tests/modules/consumers/test_simulation.py
@@ -11,7 +11,6 @@ from thrs.input_output.modules.consumers import (
 )
 from thrs.orchestration.simulation import Simulation
 from thrs.simulation.fmu import Fmu
-from thrs.simulation.io_mapping import ThrsModelIoMapping
 from thrs.simulation.models.fmu_paths import consumers_path
 
 
@@ -34,12 +33,9 @@ def incorrect_simulation_inputs(simulation_inputs, request):
 
 async def test_consumers_simulation_inputs(incorrect_simulation_inputs, control):
     with Fmu(consumers_path) as fmu:
-        mapping = ThrsModelIoMapping(
+        simulation = Simulation(
             ConsumersSensorValues,
             ConsumersSimulationOutputs,
-        )
-        simulation = Simulation(
-            mapping,
             fmu,
             incorrect_simulation_inputs,
             datetime.now(),

--- a/zero-thrs-control/tests/modules/fahrenheit/conftest.py
+++ b/zero-thrs-control/tests/modules/fahrenheit/conftest.py
@@ -16,7 +16,6 @@ from thrs.input_output.modules.fahrenheit import (
 )
 from thrs.orchestration.simulation import Simulation
 from thrs.simulation.fmu import Fmu
-from thrs.simulation.io_mapping import ThrsModelIoMapping
 from thrs.simulation.models.fmu_paths import fahrenheit_path
 
 
@@ -47,21 +46,18 @@ def simulation_inputs():
 
 
 @fixture
-def io_mapping():
-    return ThrsModelIoMapping(
-        FahrenheitSensorValues,
-        FahrenheitSimulationOutputs,
-    )
-
-
-@fixture
 def control(simulation):
     return FahrenheitControl(FahrenheitParameters(), simulation.time)
 
 
 @fixture
-def simulation(io_mapping, simulation_inputs):
+def simulation(simulation_inputs):
     with Fmu(fahrenheit_path) as fmu:
         yield Simulation(
-            io_mapping, fmu, simulation_inputs, datetime.now(), timedelta(seconds=1)
+            FahrenheitSensorValues,
+            FahrenheitSimulationOutputs,
+            fmu,
+            simulation_inputs,
+            datetime.now(),
+            timedelta(seconds=1),
         )

--- a/zero-thrs-control/tests/modules/fahrenheit/test_control.py
+++ b/zero-thrs-control/tests/modules/fahrenheit/test_control.py
@@ -13,7 +13,11 @@ from thrs.input_output.definitions.simulation import (
     Fahrenheit,
     TemperatureBoundary,
 )
-from thrs.input_output.modules.fahrenheit import FahrenheitSimulationInputs
+from thrs.input_output.modules.fahrenheit import (
+    FahrenheitSensorValues,
+    FahrenheitSimulationInputs,
+    FahrenheitSimulationOutputs,
+)
 from thrs.orchestration.simulation import Simulation
 from thrs.simulation.fmu import Fmu
 from thrs.simulation.models.fmu_paths import fahrenheit_path
@@ -192,7 +196,7 @@ async def test_waste_recovery(control: FahrenheitControl, simulation: Simulation
         )
 
 
-async def test_waste_cooling(io_mapping):
+async def test_waste_cooling():
     simulation_inputs = FahrenheitSimulationInputs(
         fahrenheit_cold_supply=TemperatureBoundary(temperature=Stamped.stamp(20.0)),
         fahrenheit_seawater_supply=Boundary(
@@ -222,7 +226,8 @@ async def test_waste_cooling(io_mapping):
 
     with Fmu(fahrenheit_path) as fmu:
         simulation = Simulation(
-            io_mapping,
+            FahrenheitSensorValues,
+            FahrenheitSimulationOutputs,
             fmu,
             simulation_inputs,
             datetime.fromtimestamp(0),

--- a/zero-thrs-control/tests/modules/fahrenheit/test_simulation.py
+++ b/zero-thrs-control/tests/modules/fahrenheit/test_simulation.py
@@ -11,7 +11,6 @@ from thrs.input_output.modules.fahrenheit import (
 )
 from thrs.orchestration.simulation import Simulation
 from thrs.simulation.fmu import Fmu
-from thrs.simulation.io_mapping import ThrsModelIoMapping
 from thrs.simulation.models.fmu_paths import fahrenheit_path
 
 
@@ -26,12 +25,9 @@ def incorrect_simulation_inputs(simulation_inputs, request):
 
 async def test_thrusters_simulation_inputs(incorrect_simulation_inputs, control):
     with Fmu(fahrenheit_path) as fmu:
-        mapping = ThrsModelIoMapping(
+        simulation = Simulation(
             FahrenheitSensorValues,
             FahrenheitSimulationOutputs,
-        )
-        simulation = Simulation(
-            mapping,
             fmu,
             incorrect_simulation_inputs,
             datetime.now(),

--- a/zero-thrs-control/tests/modules/high_temperature/conftest.py
+++ b/zero-thrs-control/tests/modules/high_temperature/conftest.py
@@ -93,13 +93,13 @@ def control(module, simulation):
 
 
 @fixture
-def io_mapping(module):
-    return module.io_mapping()
-
-
-@fixture
-def simulation(io_mapping, simulation_inputs):
+def simulation(module, simulation_inputs):
     with Fmu(high_temperature_path) as fmu:
         yield Simulation(
-            io_mapping, fmu, simulation_inputs, datetime.now(), timedelta(seconds=1)
+            module.sensor_values_cls,
+            module.simulation_outputs_cls,
+            fmu,
+            simulation_inputs,
+            datetime.now(),
+            timedelta(seconds=1),
         )

--- a/zero-thrs-control/tests/modules/high_temperature/conftest.py
+++ b/zero-thrs-control/tests/modules/high_temperature/conftest.py
@@ -96,7 +96,7 @@ def control(module, simulation):
 def simulation(module, simulation_inputs):
     with Fmu(high_temperature_path) as fmu:
         yield Simulation(
-            module.sensor_values_cls,
+            module.sensor_values_clss,
             module.simulation_outputs_cls,
             fmu,
             simulation_inputs,

--- a/zero-thrs-control/tests/modules/high_temperature/test_simulation.py
+++ b/zero-thrs-control/tests/modules/high_temperature/test_simulation.py
@@ -44,12 +44,12 @@ def incorrect_simulation_inputs(simulation_inputs, request):
 
 
 async def test_high_temperature_simulation_inputs(
-    incorrect_simulation_inputs, control, io_mapping
+    incorrect_simulation_inputs, control, module
 ):
     with Fmu(high_temperature_path) as fmu:
-        mapping = io_mapping
         simulation = Simulation(
-            mapping,
+            module.sensor_values_cls,
+            module.simulation_outputs_cls,
             fmu,
             incorrect_simulation_inputs,
             datetime.now(),

--- a/zero-thrs-control/tests/modules/high_temperature/test_simulation.py
+++ b/zero-thrs-control/tests/modules/high_temperature/test_simulation.py
@@ -79,6 +79,7 @@ async def test_module_simulator_model(module):
         simulation_inputs=inputs,
     )
     with model.simulation() as simulation:
-        runner = Runner.from_module(module, params, simulation)
+        simulation.transceive = simulation.tick  # type: ignore # TODO: Make this make sense
+        runner = Runner.from_module(module, params, simulation)  # type: ignore # TODO: Make this make sense
 
         await runner.run(100)

--- a/zero-thrs-control/tests/modules/high_temperature/test_simulation.py
+++ b/zero-thrs-control/tests/modules/high_temperature/test_simulation.py
@@ -48,7 +48,7 @@ async def test_high_temperature_simulation_inputs(
 ):
     with Fmu(high_temperature_path) as fmu:
         simulation = Simulation(
-            module.sensor_values_cls,
+            module.sensor_values_clss,
             module.simulation_outputs_cls,
             fmu,
             incorrect_simulation_inputs,

--- a/zero-thrs-control/tests/modules/lt1/conftest.py
+++ b/zero-thrs-control/tests/modules/lt1/conftest.py
@@ -135,4 +135,5 @@ def alarms() -> Lt1Alarms:
 
 @fixture()
 def runner(control: Lt1Control, simulation, alarms: Lt1Alarms) -> Runner:
+    simulation.transceive = simulation.tick  # type: ignore # TODO: Make this make sense
     return Runner(simulation, control, alarms)

--- a/zero-thrs-control/tests/modules/lt1/conftest.py
+++ b/zero-thrs-control/tests/modules/lt1/conftest.py
@@ -18,7 +18,6 @@ from thrs.input_output.modules.lt1 import (
 from thrs.orchestration.runner import Runner
 from thrs.orchestration.simulation import Simulation
 from thrs.simulation.fmu import Fmu
-from thrs.simulation.io_mapping import ThrsModelIoMapping
 from thrs.simulation.models.fmu_paths import lt1_path
 
 SEAWATER_TEMPERATURE = 20
@@ -112,18 +111,11 @@ def simulation_inputs_shorepower():
 
 
 @fixture
-def io_mapping():
-    return ThrsModelIoMapping(
-        Lt1SensorValues,
-        Lt1SimulationOutputs,
-    )
-
-
-@fixture
-def simulation(io_mapping, simulation_inputs_all_drives_active):
+def simulation(simulation_inputs_all_drives_active):
     with Fmu(lt1_path) as fmu:
         yield Simulation(
-            io_mapping,
+            Lt1SensorValues,
+            Lt1SimulationOutputs,
             fmu,
             simulation_inputs_all_drives_active,
             datetime.now(),

--- a/zero-thrs-control/tests/modules/lt1/test_simulation.py
+++ b/zero-thrs-control/tests/modules/lt1/test_simulation.py
@@ -11,7 +11,6 @@ from thrs.input_output.modules.lt1 import (
 )
 from thrs.orchestration.simulation import Simulation
 from thrs.simulation.fmu import Fmu
-from thrs.simulation.io_mapping import ThrsModelIoMapping
 from thrs.simulation.models.fmu_paths import lt1_path
 
 
@@ -30,12 +29,9 @@ async def test_simulation_step(control, simulation):
 
 async def test_lt1_simulation_inputs(incorrect_simulation_inputs, control):
     with Fmu(lt1_path) as fmu:
-        mapping = ThrsModelIoMapping(
+        simulation = Simulation(
             Lt1SensorValues,
             Lt1SimulationOutputs,
-        )
-        simulation = Simulation(
-            mapping,
             fmu,
             incorrect_simulation_inputs,
             datetime.now(),

--- a/zero-thrs-control/tests/modules/lt2/conftest.py
+++ b/zero-thrs-control/tests/modules/lt2/conftest.py
@@ -126,6 +126,7 @@ def alarms() -> Lt2Alarms:
 
 @fixture()
 def runner(control: Lt2Control, simulation, alarms: Lt2Alarms) -> Runner:
+    simulation.transceive = simulation.tick  # type: ignore # TODO: Make this make sense
     return Runner(simulation, control, alarms)
 
 

--- a/zero-thrs-control/tests/modules/lt2/conftest.py
+++ b/zero-thrs-control/tests/modules/lt2/conftest.py
@@ -13,7 +13,6 @@ from thrs.input_output.modules.lt2 import (
 from thrs.orchestration.runner import Runner
 from thrs.orchestration.simulation import Simulation
 from thrs.simulation.fmu import Fmu
-from thrs.simulation.io_mapping import ThrsModelIoMapping
 from thrs.simulation.models.fmu_paths import lt2_path
 
 SEAWATER_TEMPERATURE = 20
@@ -131,16 +130,13 @@ def runner(control: Lt2Control, simulation, alarms: Lt2Alarms) -> Runner:
 
 
 @fixture
-def io_mapping():
-    return ThrsModelIoMapping(
-        Lt2SensorValues,
-        Lt2SimulationOutputs,
-    )
-
-
-@fixture
-def simulation(io_mapping, simulation_inputs):
+def simulation(simulation_inputs):
     with Fmu(lt2_path) as fmu:
         yield Simulation(
-            io_mapping, fmu, simulation_inputs, datetime.now(), timedelta(seconds=1)
+            Lt2SensorValues,
+            Lt2SimulationOutputs,
+            fmu,
+            simulation_inputs,
+            datetime.now(),
+            timedelta(seconds=1),
         )

--- a/zero-thrs-control/tests/modules/lt2/test_simulation.py
+++ b/zero-thrs-control/tests/modules/lt2/test_simulation.py
@@ -12,7 +12,6 @@ from thrs.input_output.modules.lt2 import (
 )
 from thrs.orchestration.simulation import Simulation
 from thrs.simulation.fmu import Fmu
-from thrs.simulation.io_mapping import ThrsModelIoMapping
 from thrs.simulation.models.fmu_paths import lt2_path
 
 
@@ -31,12 +30,9 @@ async def test_simulation_step(control, simulation):
 
 async def test_lt2_simulation_inputs(incorrect_simulation_inputs):
     with Fmu(lt2_path) as fmu:
-        mapping = ThrsModelIoMapping(
+        simulation = Simulation(
             Lt2SensorValues,
             Lt2SimulationOutputs,
-        )
-        simulation = Simulation(
-            mapping,
             fmu,
             incorrect_simulation_inputs,
             datetime.now(),

--- a/zero-thrs-control/tests/modules/pcm/conftest.py
+++ b/zero-thrs-control/tests/modules/pcm/conftest.py
@@ -12,7 +12,6 @@ from thrs.input_output.modules.pcm import (
 )
 from thrs.orchestration.simulation import Simulation
 from thrs.simulation.fmu import Fmu
-from thrs.simulation.io_mapping import ThrsModelIoMapping
 from thrs.simulation.models.fmu_paths import pcm_path
 
 
@@ -35,16 +34,13 @@ def simulation_inputs():
 
 
 @fixture
-def io_mapping():
-    return ThrsModelIoMapping(
-        PcmSensorValues,
-        PcmSimulationOutputs,
-    )
-
-
-@fixture
-def simulation(io_mapping, simulation_inputs):
+def simulation(simulation_inputs):
     with Fmu(pcm_path) as fmu:
         yield Simulation(
-            io_mapping, fmu, simulation_inputs, datetime.now(), timedelta(seconds=1)
+            PcmSensorValues,
+            PcmSimulationOutputs,
+            fmu,
+            simulation_inputs,
+            datetime.now(),
+            timedelta(seconds=1),
         )

--- a/zero-thrs-control/tests/modules/pcm/test_simulation.py
+++ b/zero-thrs-control/tests/modules/pcm/test_simulation.py
@@ -11,7 +11,6 @@ from thrs.input_output.modules.pcm import (
 )
 from thrs.orchestration.simulation import Simulation
 from thrs.simulation.fmu import Fmu
-from thrs.simulation.io_mapping import ThrsModelIoMapping
 from thrs.simulation.models.fmu_paths import pcm_path
 
 
@@ -36,12 +35,9 @@ def incorrect_simulation_inputs(simulation_inputs, request):
 
 async def test_pcm_simulation_inputs(incorrect_simulation_inputs, control):
     with Fmu(pcm_path) as fmu:
-        mapping = ThrsModelIoMapping(
+        simulation = Simulation(
             PcmSensorValues,
             PcmSimulationOutputs,
-        )
-        simulation = Simulation(
-            mapping,
             fmu,
             incorrect_simulation_inputs,
             datetime.now(),

--- a/zero-thrs-control/tests/modules/pvt/conftest.py
+++ b/zero-thrs-control/tests/modules/pvt/conftest.py
@@ -16,7 +16,6 @@ from thrs.input_output.modules.pvt import (
 )
 from thrs.orchestration.simulation import Simulation
 from thrs.simulation.fmu import Fmu
-from thrs.simulation.io_mapping import ThrsModelIoMapping
 from thrs.simulation.models.fmu_paths import pvt_path
 
 
@@ -34,21 +33,18 @@ def simulation_inputs():
 
 
 @fixture
-def io_mapping():
-    return ThrsModelIoMapping(
-        PvtSensorValues,
-        PvtSimulationOutputs,
-    )
-
-
-@fixture
 def control(simulation):
     return PvtControl(PvtParameters(), simulation.time)
 
 
 @fixture
-def simulation(io_mapping, simulation_inputs):
+def simulation(simulation_inputs):
     with Fmu(pvt_path) as fmu:
         yield Simulation(
-            io_mapping, fmu, simulation_inputs, datetime.now(), timedelta(seconds=1)
+            PvtSensorValues,
+            PvtSimulationOutputs,
+            fmu,
+            simulation_inputs,
+            datetime.now(),
+            timedelta(seconds=1),
         )

--- a/zero-thrs-control/tests/modules/pvt/test_simulation.py
+++ b/zero-thrs-control/tests/modules/pvt/test_simulation.py
@@ -11,7 +11,6 @@ from thrs.input_output.modules.pvt import (
 )
 from thrs.orchestration.simulation import Simulation
 from thrs.simulation.fmu import Fmu
-from thrs.simulation.io_mapping import ThrsModelIoMapping
 from thrs.simulation.models.fmu_paths import pvt_path
 
 
@@ -36,12 +35,9 @@ def incorrect_simulation_inputs(simulation_inputs, request):
 
 async def test_thrusters_simulation_inputs(incorrect_simulation_inputs, control):
     with Fmu(pvt_path) as fmu:
-        mapping = ThrsModelIoMapping(
+        simulation = Simulation(
             PvtSensorValues,
             PvtSimulationOutputs,
-        )
-        simulation = Simulation(
-            mapping,
             fmu,
             incorrect_simulation_inputs,
             datetime.now(),

--- a/zero-thrs-control/tests/modules/thrusters/conftest.py
+++ b/zero-thrs-control/tests/modules/thrusters/conftest.py
@@ -23,7 +23,6 @@ from thrs.input_output.modules.thrusters import (
 )
 from thrs.orchestration.simulation import Simulation
 from thrs.simulation.fmu import Fmu
-from thrs.simulation.io_mapping import ThrsModelIoMapping
 from thrs.simulation.models.fmu_paths import thrusters_path
 
 type ThrustersSimulation = Simulation[
@@ -52,22 +51,19 @@ def simulation_inputs():
 
 
 @fixture
-def io_mapping():
-    return ThrsModelIoMapping(
-        ThrustersSensorValues,
-        ThrustersSimulationOutputs,
-    )
-
-
-@fixture
 def control(simulation):
     return ThrustersControl(ThrustersParameters(), simulation.time)
 
 
 @fixture
-def simulation(fmu, io_mapping, simulation_inputs) -> ThrustersSimulation:
+def simulation(fmu, simulation_inputs) -> ThrustersSimulation:
     return Simulation(
-        io_mapping, fmu, simulation_inputs, datetime.now(), timedelta(seconds=1)
+        ThrustersSensorValues,
+        ThrustersSimulationOutputs,
+        fmu,
+        simulation_inputs,
+        datetime.now(),
+        timedelta(seconds=1),
     )
 
 

--- a/zero-thrs-control/tests/modules/thrusters/test_simulation.py
+++ b/zero-thrs-control/tests/modules/thrusters/test_simulation.py
@@ -21,16 +21,12 @@ from thrs.orchestration.collector import PolarsCollector
 from thrs.orchestration.runner import Runner, SimulatorModel
 from thrs.orchestration.simulation import Simulation
 from thrs.simulation.fmu import Fmu
-from thrs.simulation.io_mapping import (
-    ThrsModelIoMapping,
-    flatten_model_values,
-)
+from thrs.simulation.io_mapping import ThrsModelIoMapping, flatten_model_values
 from thrs.simulation.models.fmu_paths import thrusters_path
 
 
-async def test_interfacer(
-    simulation, fmu, io_mapping, simulation_inputs, control, alarms
-):
+async def test_interfacer(simulation, fmu, simulation_inputs, control, alarms):
+    io_mapping = ThrsModelIoMapping(ThrustersSensorValues, ThrustersSimulationOutputs)
     collector = PolarsCollector()
     runner = Runner(simulation, control, alarms)
     await runner.run(20, collector)
@@ -68,7 +64,7 @@ async def test_interfacer(
 
 
 async def test_computed_collection(
-    simulation: ThrustersSimulation, io_mapping, simulation_inputs, control, alarms
+    simulation: ThrustersSimulation, simulation_inputs, control, alarms
 ):
     collector = PolarsCollector()
     runner = Runner(simulation, control, alarms)  # TODO: Make this make sense
@@ -114,12 +110,9 @@ def incorrect_simulation_inputs(simulation_inputs, request):
 
 async def test_thrusters_simulation_inputs(incorrect_simulation_inputs, control):
     with Fmu(thrusters_path) as fmu:
-        mapping = ThrsModelIoMapping(
+        simulation = Simulation(
             ThrustersSensorValues,
             ThrustersSimulationOutputs,
-        )
-        simulation = Simulation(
-            mapping,
             fmu,
             incorrect_simulation_inputs,
             datetime.now(),

--- a/zero-thrs-control/tests/modules/thrusters/test_simulation.py
+++ b/zero-thrs-control/tests/modules/thrusters/test_simulation.py
@@ -28,6 +28,7 @@ from thrs.simulation.models.fmu_paths import thrusters_path
 async def test_interfacer(simulation, fmu, simulation_inputs, control, alarms):
     io_mapping = ThrsModelIoMapping(ThrustersSensorValues, ThrustersSimulationOutputs)
     collector = PolarsCollector()
+    simulation.transceive = simulation.tick  # type: ignore # TODO: Make this make sense
     runner = Runner(simulation, control, alarms)
     await runner.run(20, collector)
     frame = collector.result()
@@ -67,7 +68,8 @@ async def test_computed_collection(
     simulation: ThrustersSimulation, simulation_inputs, control, alarms
 ):
     collector = PolarsCollector()
-    runner = Runner(simulation, control, alarms)  # TODO: Make this make sense
+    simulation.transceive = simulation.tick  # type: ignore # TODO: Make this make sense
+    runner = Runner(simulation, control, alarms)  # type: ignore # TODO: Make this make sense
     await runner.run(20, collector)
     frame = collector.result()
     assert frame is not None
@@ -86,10 +88,11 @@ async def test_simulation(simulation_inputs, control, alarms):
     )
 
     with thrusters_model.simulation() as simulation:
+        simulation.transceive = simulation.tick  # type: ignore # TODO: Make this make sense
         runner = Runner.from_module(
             THRUSTERS_MODULE_DESCRIPTION,
             ThrustersParameters(),
-            simulation,  # TODO: Make this make sense
+            simulation,  # type: ignore # TODO: Make this make sense
         )
 
         collector = PolarsCollector()

--- a/zero-thrs-control/tests/modules/thrusters/test_valve_movement.py
+++ b/zero-thrs-control/tests/modules/thrusters/test_valve_movement.py
@@ -2,12 +2,21 @@ from datetime import datetime, timedelta
 
 from pytest import approx
 
+from thrs.input_output.modules.thrusters import (
+    ThrustersSensorValues,
+    ThrustersSimulationOutputs,
+)
 from thrs.orchestration.simulation import Simulation
 
 
-async def test_valve_movement(io_mapping, fmu, control, simulation_inputs):
+async def test_valve_movement(fmu, control, simulation_inputs):
     simulation = Simulation(
-        io_mapping, fmu, simulation_inputs, datetime.now(), timedelta(seconds=45)
+        ThrustersSensorValues,
+        ThrustersSimulationOutputs,
+        fmu,
+        simulation_inputs,
+        datetime.now(),
+        timedelta(seconds=45),
     )
 
     control_values = control.initial().values

--- a/zero-thrs-control/tests/orchestration/simples.py
+++ b/zero-thrs-control/tests/orchestration/simples.py
@@ -29,7 +29,7 @@ class SimpleConnector(Connector):
     async def start(self):
         pass
 
-    async def tick(self, control_values):
+    async def transceive(self, control_values):
         self.controls.append(control_values)
         return ExecutionResult(timestamp=datetime.now(), sensor_values=control_values)
 

--- a/zero-thrs-control/tests/orchestration/test_connector.py
+++ b/zero-thrs-control/tests/orchestration/test_connector.py
@@ -38,25 +38,28 @@ mqtt_client2 = pytest.fixture(_mqtt_client)
 
 async def test_mqtt_connector(mqtt_client, mqtt_client2):
     simple_simulation = SimpleSimulation(datetime.now())
+    module = CombinedModule(
+        {
+            "simple": ModuleDescription(
+                SimpleInOut,
+                SimpleInOut,
+                SimpleParameters,
+                SimpleControl,
+                SimpleMode,
+                SimpleAlarms,
+            )
+        },
+        cast(type[SimulationInputs], SimpleInOut),
+        cast(type[SimulationValues], SimpleInOut),
+    )
     connector = MqttConnector(
         simple_simulation,
         mqtt_client,
         mqtt_client2,
         f"{settings.mqtt_topic_prefix}/simple",
-        CombinedModule(
-            {
-                "simple": ModuleDescription(
-                    SimpleInOut,
-                    SimpleInOut,
-                    SimpleParameters,
-                    SimpleControl,
-                    SimpleMode,
-                    SimpleAlarms,
-                )
-            },
-            cast(type[SimulationInputs], SimpleInOut),
-            cast(type[SimulationValues], SimpleInOut),
-        ),
+        module.sensor_values_mqtt_mapping,
+        module.control_values_mqtt_mapping,
+        module.simulation_output_mqtt_mapping,
     )
     await connector.start()
     running = create_task(connector.run())
@@ -121,23 +124,25 @@ async def test_mqtt_connector(mqtt_client, mqtt_client2):
 
 
 async def test_boat_connector_echoes_controls_to_sensors(mqtt_client):
+    module = CombinedModule(
+        {
+            "simple": ModuleDescription(
+                SimpleInOut,
+                SimpleInOut,
+                SimpleParameters,
+                SimpleControl,
+                SimpleMode,
+                SimpleAlarms,
+            )
+        },
+        cast(type[SimulationInputs], SimpleInOut),
+        cast(type[SimulationValues], SimpleInOut),
+    )
     connector = MqttControlConnector(
         mqtt_client,
         f"{settings.mqtt_topic_prefix}/simple",
-        CombinedModule(
-            {
-                "simple": ModuleDescription(
-                    SimpleInOut,
-                    SimpleInOut,
-                    SimpleParameters,
-                    SimpleControl,
-                    SimpleMode,
-                    SimpleAlarms,
-                )
-            },
-            cast(type[SimulationInputs], SimpleInOut),
-            cast(type[SimulationValues], SimpleInOut),
-        ),
+        module.sensor_values_mqtt_mapping,
+        module.control_values_mqtt_mapping,
     )
     await connector.start()
     running = create_task(connector.run())

--- a/zero-thrs-control/tests/orchestration/test_connector.py
+++ b/zero-thrs-control/tests/orchestration/test_connector.py
@@ -212,7 +212,7 @@ async def test_mqtt_connector(mqtt_client, mqtt_client2):
     await sleep(0)
 
     try:
-        first_result = await connector.tick(
+        first_result = await connector.transceive(
             CombinedValues(
                 values={
                     "simple": SimpleInOut(
@@ -230,7 +230,7 @@ async def test_mqtt_connector(mqtt_client, mqtt_client2):
             == 2
         )
         await sleep(0.005)
-        second_result = await connector.tick(
+        second_result = await connector.transceive(
             CombinedValues(
                 values={
                     "simple": SimpleInOut(
@@ -248,7 +248,7 @@ async def test_mqtt_connector(mqtt_client, mqtt_client2):
             == 2
         )
         await sleep(0.1)
-        third_result = await connector.tick(
+        third_result = await connector.transceive(
             CombinedValues(
                 {
                     "simple": SimpleInOut(
@@ -295,7 +295,7 @@ async def test_boat_connector_echoes_controls_to_sensors(mqtt_client):
     await sleep(0)
 
     try:
-        empty_result = await connector.tick(
+        empty_result = await connector.transceive(
             CombinedValues(
                 values={
                     "simple": SimpleInOut(
@@ -310,7 +310,7 @@ async def test_boat_connector_echoes_controls_to_sensors(mqtt_client):
 
         await sleep(0.005)
 
-        first_result = await connector.tick(
+        first_result = await connector.transceive(
             CombinedValues(
                 values={
                     "simple": SimpleInOut(
@@ -330,7 +330,7 @@ async def test_boat_connector_echoes_controls_to_sensors(mqtt_client):
 
         await sleep(0.1)
 
-        second_result = await connector.tick(
+        second_result = await connector.transceive(
             CombinedValues(
                 values={
                     "simple": SimpleInOut(

--- a/zero-thrs-control/tests/orchestration/test_connector.py
+++ b/zero-thrs-control/tests/orchestration/test_connector.py
@@ -18,13 +18,159 @@ from thrs.input_output.base import (
     SimulationInputs,
     SimulationValues,
     Stamped,
+    ThrsValues,
 )
 from thrs.input_output.definitions.sensor import FlowSensor
 from thrs.orchestration.config import Config
-from thrs.orchestration.connector import MqttConnector, MqttControlConnector
+from thrs.orchestration.connector import (
+    DirectMqttMapping,
+    ModuleMqttMapping,
+    MqttConnector,
+    MqttControlConnector,
+    PartialMqttMapping,
+)
 from thrs.orchestration.module import CombinedModule, ModuleDescription
 
 settings = Config()  # type: ignore
+
+
+class TestPartialMqttMapping:
+    def test_split_to_topics_without_suffix(self):
+        mapping = PartialMqttMapping(SimpleInOut)
+        flow_sensor = FlowSensor(
+            flow=Stamped.stamp(10.0), temperature=Stamped.stamp(25.0)
+        )
+        model = SimpleInOut(go_with_the=flow_sensor)
+
+        topics = mapping.split_to_topics(model)
+
+        assert "go-with-the" in topics
+        topic = topics["go-with-the"]
+        assert FlowSensor.model_validate_json(topic) == flow_sensor
+
+    def test_split_to_topics_with_suffix(self):
+        mapping = PartialMqttMapping(SimpleInOut, "sensors")
+        flow_sensor = FlowSensor(
+            flow=Stamped.stamp(10.0), temperature=Stamped.stamp(25.0)
+        )
+        model = SimpleInOut(go_with_the=flow_sensor)
+
+        topics = mapping.split_to_topics(model)
+
+        assert "go-with-the/sensors" in topics
+        topic = topics["go-with-the/sensors"]
+        assert FlowSensor.model_validate_json(topic) == flow_sensor
+
+    def test_has_without_suffix(self):
+        mapping = PartialMqttMapping(SimpleInOut)
+
+        assert mapping.has("go-with-the")
+        assert not mapping.has("nonexistent")
+
+    def test_has_with_suffix(self):
+        mapping = PartialMqttMapping(SimpleInOut, "sensors")
+
+        assert mapping.has("go-with-the/sensors")
+        assert not mapping.has("go-with-the")
+
+    def test_subscribe_topic(self):
+        mapping_no_suffix = PartialMqttMapping(SimpleInOut)
+        mapping_with_suffix = PartialMqttMapping(SimpleInOut, "sensors")
+
+        assert mapping_no_suffix.subscribe_topic() == "+"
+        assert mapping_with_suffix.subscribe_topic() == "+/sensors"
+
+    def test_builder(self):
+        mapping = PartialMqttMapping(SimpleInOut)
+        builder = mapping.builder()
+
+        flow_sensor = FlowSensor(
+            flow=Stamped.stamp(15.0), temperature=Stamped.stamp(30.0)
+        )
+        builder.input("go-with-the", flow_sensor.model_dump_json(by_alias=True))
+        assert builder.result() == SimpleInOut(go_with_the=flow_sensor)
+
+
+class TestDirectMqttMapping:
+    def test_split_to_topics(self):
+        mapping = DirectMqttMapping(SimpleInOut, "sensors/data")
+        model = SimpleInOut(
+            go_with_the=FlowSensor(
+                flow=Stamped.stamp(25.0), temperature=Stamped.stamp(1.2)
+            )
+        )
+        topics = mapping.split_to_topics(model)
+
+        assert "sensors/data" in topics
+        assert topics["sensors/data"] == model.model_dump_json(by_alias=True)
+
+    def test_has(self):
+        mapping = DirectMqttMapping(SimpleInOut, "sensors/data")
+
+        assert mapping.has("sensors/data")
+        assert not mapping.has("other/topic")
+
+    def test_subscribe_topic(self):
+        mapping = DirectMqttMapping(SimpleInOut, "sensors/data")
+
+        assert mapping.subscribe_topic() == "sensors/data"
+
+    def test_builder_not_implemented(self):
+        mapping = DirectMqttMapping(SimpleInOut, "sensors/data")
+        with pytest.raises(NotImplementedError):
+            mapping.builder()
+
+
+class ModulesValues(ThrsValues):
+    module1: SimpleInOut
+
+
+class TestCombinedMqttMapping:
+    def test_split_to_topics(self):
+        clss = {"module1": SimpleInOut}
+        mapping = ModuleMqttMapping(clss)
+        flow_sensor = FlowSensor(
+            flow=Stamped.stamp(25.0), temperature=Stamped.stamp(1.2)
+        )
+        combined_values = CombinedValues(
+            values={"module1": SimpleInOut(go_with_the=flow_sensor)}
+        )
+
+        topics = mapping.split_to_topics(combined_values)
+
+        assert "module1/go-with-the" in topics
+        assert topics["module1/go-with-the"] == flow_sensor.model_dump_json(
+            by_alias=True
+        )
+
+    def test_has(self):
+        clss = {"module1": SimpleInOut}
+        mapping = ModuleMqttMapping(clss)
+
+        assert mapping.has("module1/go-with-the")
+        assert not mapping.has("module2/go-with-the")
+
+    def test_subscribe_topic(self):
+        clss = {"module1": SimpleInOut}
+        mapping_no_suffix = ModuleMqttMapping(clss)
+        mapping_with_suffix = ModuleMqttMapping(clss, "sensors")
+
+        assert mapping_no_suffix.subscribe_topic() == "+/+"
+        assert mapping_with_suffix.subscribe_topic() == "+/+/sensors"
+
+    def test_builder(self):
+        clss = {"module1": SimpleInOut}
+        mapping = ModuleMqttMapping(clss)
+        builder = mapping.builder()
+
+        flow_sensor = FlowSensor(
+            flow=Stamped.stamp(50.0), temperature=Stamped.stamp(5.0)
+        )
+        builder.input("module1/go-with-the", flow_sensor.model_dump_json(by_alias=True))
+        result = builder.result()
+        assert result == CombinedValues(
+            {"module1": SimpleInOut(go_with_the=flow_sensor)}
+        )
 
 
 async def _mqtt_client():
@@ -57,9 +203,9 @@ async def test_mqtt_connector(mqtt_client, mqtt_client2):
         mqtt_client,
         mqtt_client2,
         f"{settings.mqtt_topic_prefix}/simple",
-        module.sensor_values_mqtt_mapping,
-        module.control_values_mqtt_mapping,
-        module.simulation_output_mqtt_mapping,
+        module.sensor_values_clss,
+        module.control_values_clss,
+        module.simulation_outputs_cls,
     )
     await connector.start()
     running = create_task(connector.run())
@@ -141,8 +287,8 @@ async def test_boat_connector_echoes_controls_to_sensors(mqtt_client):
     connector = MqttControlConnector(
         mqtt_client,
         f"{settings.mqtt_topic_prefix}/simple",
-        module.sensor_values_mqtt_mapping,
-        module.control_values_mqtt_mapping,
+        module.sensor_values_clss,
+        module.control_values_clss,
     )
     await connector.start()
     running = create_task(connector.run())

--- a/zero-thrs-control/tests/orchestration/test_module.py
+++ b/zero-thrs-control/tests/orchestration/test_module.py
@@ -159,7 +159,7 @@ class TestModuleNesting:
         assert combined_module.control_values_for_module("module1") == SimpleInOut
         assert combined_module.parameters_for_module("module1") == SimpleParameters
 
-    def test_sensor_values_cls(self):
+    def test_sensor_values_clss(self):
         control_fn = Mock()
         alarms_fn = Mock()
 
@@ -178,7 +178,7 @@ class TestModuleNesting:
             modules, SimpleSimulationInputs, SimpleSimulationOutputs
         )
 
-        assert nesting.sensor_values_cls is not None
+        assert nesting.sensor_values_clss is not None
 
     def test_control(self):
         mock_control_instance = Mock(spec=Control)

--- a/zero-thrs-control/tests/orchestration/test_module.py
+++ b/zero-thrs-control/tests/orchestration/test_module.py
@@ -159,7 +159,7 @@ class TestModuleNesting:
         assert combined_module.control_values_for_module("module1") == SimpleInOut
         assert combined_module.parameters_for_module("module1") == SimpleParameters
 
-    def test_io_mapping(self):
+    def test_sensor_values_cls(self):
         control_fn = Mock()
         alarms_fn = Mock()
 
@@ -178,8 +178,7 @@ class TestModuleNesting:
             modules, SimpleSimulationInputs, SimpleSimulationOutputs
         )
 
-        io_mapping = nesting.io_mapping()
-        assert io_mapping is not None
+        assert nesting.sensor_values_cls is not None
 
     def test_control(self):
         mock_control_instance = Mock(spec=Control)

--- a/zero-thrs-control/tests/orchestration/test_module.py
+++ b/zero-thrs-control/tests/orchestration/test_module.py
@@ -1,8 +1,6 @@
 from datetime import datetime
 from unittest.mock import Mock
 
-import pytest
-
 from tests.orchestration.simples import (
     SimpleControl,
     SimpleInOut,
@@ -16,11 +14,6 @@ from thrs.control.base import ModuleDescription
 from thrs.input_output.alarms import Alarm, BaseAlarms, Severity
 from thrs.input_output.base import CombinedValues, Stamped, ThrsValues
 from thrs.input_output.definitions.sensor import FlowSensor
-from thrs.orchestration.connector import (
-    DirectMqttMapping,
-    ModuleMqttMapping,
-    PartialMqttMapping,
-)
 from thrs.orchestration.module import (
     CombinedAlarms,
     CombinedControl,
@@ -39,141 +32,6 @@ class MockSimulationInputs(ThrsValues):
 
 class MockSimulationOutputs(ThrsValues):
     output_value: float = 20.0
-
-
-class TestPartialMqttMapping:
-    def test_split_to_topics_without_suffix(self):
-        mapping = PartialMqttMapping(SimpleInOut)
-        flow_sensor = FlowSensor(
-            flow=Stamped.stamp(10.0), temperature=Stamped.stamp(25.0)
-        )
-        model = SimpleInOut(go_with_the=flow_sensor)
-
-        topics = mapping.split_to_topics(model)
-
-        assert "go-with-the" in topics
-        topic = topics["go-with-the"]
-        assert FlowSensor.model_validate_json(topic) == flow_sensor
-
-    def test_split_to_topics_with_suffix(self):
-        mapping = PartialMqttMapping(SimpleInOut, "sensors")
-        flow_sensor = FlowSensor(
-            flow=Stamped.stamp(10.0), temperature=Stamped.stamp(25.0)
-        )
-        model = SimpleInOut(go_with_the=flow_sensor)
-
-        topics = mapping.split_to_topics(model)
-
-        assert "go-with-the/sensors" in topics
-        topic = topics["go-with-the/sensors"]
-        assert FlowSensor.model_validate_json(topic) == flow_sensor
-
-    def test_has_without_suffix(self):
-        mapping = PartialMqttMapping(SimpleInOut)
-
-        assert mapping.has("go-with-the")
-        assert not mapping.has("nonexistent")
-
-    def test_has_with_suffix(self):
-        mapping = PartialMqttMapping(SimpleInOut, "sensors")
-
-        assert mapping.has("go-with-the/sensors")
-        assert not mapping.has("go-with-the")
-
-    def test_subscribe_topic(self):
-        mapping_no_suffix = PartialMqttMapping(SimpleInOut)
-        mapping_with_suffix = PartialMqttMapping(SimpleInOut, "sensors")
-
-        assert mapping_no_suffix.subscribe_topic() == "+"
-        assert mapping_with_suffix.subscribe_topic() == "+/sensors"
-
-    def test_builder(self):
-        mapping = PartialMqttMapping(SimpleInOut)
-        builder = mapping.builder()
-
-        flow_sensor = FlowSensor(
-            flow=Stamped.stamp(15.0), temperature=Stamped.stamp(30.0)
-        )
-        builder.input("go-with-the", flow_sensor.model_dump_json(by_alias=True))
-        assert builder.result() == SimpleInOut(go_with_the=flow_sensor)
-
-
-class TestDirectMqttMapping:
-    def test_split_to_topics(self):
-        mapping = DirectMqttMapping(SimpleInOut, "sensors/data")
-        model = SimpleInOut(
-            go_with_the=FlowSensor(
-                flow=Stamped.stamp(25.0), temperature=Stamped.stamp(1.2)
-            )
-        )
-        topics = mapping.split_to_topics(model)
-
-        assert "sensors/data" in topics
-        assert topics["sensors/data"] == model.model_dump_json(by_alias=True)
-
-    def test_has(self):
-        mapping = DirectMqttMapping(SimpleInOut, "sensors/data")
-
-        assert mapping.has("sensors/data")
-        assert not mapping.has("other/topic")
-
-    def test_subscribe_topic(self):
-        mapping = DirectMqttMapping(SimpleInOut, "sensors/data")
-
-        assert mapping.subscribe_topic() == "sensors/data"
-
-    def test_builder_not_implemented(self):
-        mapping = DirectMqttMapping(SimpleInOut, "sensors/data")
-        with pytest.raises(NotImplementedError):
-            mapping.builder()
-
-
-class TestCombinedMqttMapping:
-    def test_split_to_topics(self):
-        clss = {"module1": SimpleInOut}
-        mapping = ModuleMqttMapping(clss)
-        flow_sensor = FlowSensor(
-            flow=Stamped.stamp(25.0), temperature=Stamped.stamp(1.2)
-        )
-        combined_values = CombinedValues(
-            values={"module1": SimpleInOut(go_with_the=flow_sensor)}
-        )
-
-        topics = mapping.split_to_topics(combined_values)
-
-        assert "module1/go-with-the" in topics
-        assert topics["module1/go-with-the"] == flow_sensor.model_dump_json(
-            by_alias=True
-        )
-
-    def test_has(self):
-        clss = {"module1": SimpleInOut}
-        mapping = ModuleMqttMapping(clss)
-
-        assert mapping.has("module1/go-with-the")
-        assert not mapping.has("module2/go-with-the")
-
-    def test_subscribe_topic(self):
-        clss = {"module1": SimpleInOut}
-        mapping_no_suffix = ModuleMqttMapping(clss)
-        mapping_with_suffix = ModuleMqttMapping(clss, "sensors")
-
-        assert mapping_no_suffix.subscribe_topic() == "+/+"
-        assert mapping_with_suffix.subscribe_topic() == "+/+/sensors"
-
-    def test_builder(self):
-        clss = {"module1": SimpleInOut}
-        mapping = ModuleMqttMapping(clss)
-        builder = mapping.builder()
-
-        flow_sensor = FlowSensor(
-            flow=Stamped.stamp(50.0), temperature=Stamped.stamp(5.0)
-        )
-        builder.input("module1/go-with-the", flow_sensor.model_dump_json(by_alias=True))
-        result = builder.result()
-        assert result == CombinedValues(
-            {"module1": SimpleInOut(go_with_the=flow_sensor)}
-        )
 
 
 class TestCombinedControl:

--- a/zero-thrs-control/tests/orchestration/test_module.py
+++ b/zero-thrs-control/tests/orchestration/test_module.py
@@ -12,17 +12,19 @@ from tests.orchestration.simples import (
     SimpleSimulationOutputs,
 )
 from thrs.classes.control import Control, ControlResult
+from thrs.control.base import ModuleDescription
 from thrs.input_output.alarms import Alarm, BaseAlarms, Severity
 from thrs.input_output.base import CombinedValues, Stamped, ThrsValues
 from thrs.input_output.definitions.sensor import FlowSensor
+from thrs.orchestration.connector import (
+    DirectMqttMapping,
+    ModuleMqttMapping,
+    PartialMqttMapping,
+)
 from thrs.orchestration.module import (
     CombinedAlarms,
     CombinedControl,
     CombinedModule,
-    DirectMqttMapping,
-    ModuleDescription,
-    ModuleMqttMapping,
-    PartialMqttMapping,
 )
 
 


### PR DESCRIPTION
To be able to move the mqtt related stuff out of the other logic I slightly changed where the mappings are generated and change things so we now communicate the sensor and control values classes instead of the mappings