### PR TITLE
Remove MqttConnector (the combined sim+control version)

### DIFF
--- a/zero-thrs-control/src/thrs/cli/simulation_controls.py
+++ b/zero-thrs-control/src/thrs/cli/simulation_controls.py
@@ -63,7 +63,10 @@ from thrs.input_output.modules.thrusters import (
     ThrustersSimulationOutputs,
 )
 from thrs.orchestration.config import Config
-from thrs.orchestration.connector import MqttConnector
+from thrs.orchestration.connector import (
+    MqttConnector,
+    MqttSimulationConnector,
+)
 from thrs.orchestration.module import CombinedControl, CombinedModule
 from thrs.orchestration.runner import Runner
 from thrs.orchestration.simulation import Simulation
@@ -801,21 +804,31 @@ class SimulationControls:
                     ControlModeMessage(module=module, mode=control.mode_for(module)),
                 )
 
-            connector = MqttConnector(
-                simulation,
-                self._control_client,
-                self._sensor_client,
-                self._devices_topic_prefix,
-                self._controller_topic_prefix,
-                self._simulation_topic_prefix,
-                modules.sensor_values_clss,
-                modules.control_values_clss,
-                modules.simulation_outputs_cls,
-                self._control_topic_suffix,
+            control_connector = MqttConnector(
+                mqtt_client=self._control_client,
+                devices_topic_prefix=self._devices_topic_prefix,
+                controller_topic_prefix=self._controller_topic_prefix,
+                sensor_values_clss=modules.sensor_values_clss,
+                control_values_clss=modules.control_values_clss,
+                control_topic_suffix=self._control_topic_suffix,
             )
-            runner = Runner(connector, control, modules.alarms())  # type: ignore
+            simulation_connector = MqttSimulationConnector(
+                simulation=simulation,
+                mqtt_client=self._sensor_client,
+                devices_topic_prefix=self._devices_topic_prefix,
+                simulation_topic_prefix=self._simulation_topic_prefix,
+                sensor_values_clss=modules.sensor_values_clss,
+                simulation_outputs_cls=modules.simulation_outputs_cls,
+            )
 
-            connector_task = create_task(connector.run())
+            runner = Runner(
+                control_connector,
+                simulation_connector,
+                control,  # type: ignore
+                modules.alarms(),  # type: ignore
+            )
+
+            connector_task = create_task(control_connector.run())
             receive_task = create_task(
                 self._receive_controls(
                     SIMULATION_HANDLERS,

--- a/zero-thrs-control/src/thrs/orchestration/connector.py
+++ b/zero-thrs-control/src/thrs/orchestration/connector.py
@@ -175,7 +175,7 @@ class Connector[S, C](Protocol):
     async def transceive(self, control_values: C) -> S: ...
 
 
-class MqttControlConnector(Connector[CombinedValues, CombinedValues]):
+class MqttConnector(Connector[CombinedValues, CombinedValues]):
     def __init__(
         self,
         mqtt_client: Client,
@@ -309,45 +309,3 @@ class MqttSimulationConnector(Connector[CombinedValues, CombinedValues]):
         await self._send_simulation_output(simulation_result)
 
         return simulation_result.sensor_values
-
-
-class MqttConnector(Connector[CombinedValues, CombinedValues]):
-    # Compatibility wrapper composed from split connectors:
-    # - MqttControlConnector handles controller-side MQTT I/O
-    # - MqttSimulationConnector handles simulation-side execution and publishing
-    def __init__(
-        self,
-        simulation: "Simulation",
-        controller_client: Client,
-        environment_client: Client,
-        devices_topic_prefix: str,
-        controller_topic_prefix: str,
-        simulation_topic_prefix: str,
-        sensor_values_clss: ModuleClassMap,
-        control_values_clss: ModuleClassMap,
-        simulation_outputs_cls: type[ThrsValues],
-        control_topic_suffix: str | None = None,
-    ):
-        self._control_connector = MqttControlConnector(
-            mqtt_client=controller_client,
-            devices_topic_prefix=devices_topic_prefix,
-            controller_topic_prefix=controller_topic_prefix,
-            sensor_values_clss=sensor_values_clss,
-            control_values_clss=control_values_clss,
-            control_topic_suffix=control_topic_suffix,
-        )
-        self._simulation_connector = MqttSimulationConnector(
-            simulation=simulation,
-            mqtt_client=environment_client,
-            devices_topic_prefix=devices_topic_prefix,
-            simulation_topic_prefix=simulation_topic_prefix,
-            sensor_values_clss=sensor_values_clss,
-            simulation_outputs_cls=simulation_outputs_cls,
-        )
-
-    async def run(self):
-        await self._control_connector.run()
-
-    async def transceive(self, control_values: CombinedValues) -> CombinedValues:
-        await self._control_connector.transceive(control_values)
-        return await self._simulation_connector.transceive(control_values)

--- a/zero-thrs-control/src/thrs/orchestration/runner.py
+++ b/zero-thrs-control/src/thrs/orchestration/runner.py
@@ -12,7 +12,11 @@ from thrs.input_output.base import (
     SimulationValues,
     ThrsValues,
 )
-from thrs.orchestration.connector import Connector
+from thrs.orchestration.connector import (
+    Connector,
+    MqttConnector,
+    MqttSimulationConnector,
+)
 from thrs.orchestration.module import CombinedModule
 from thrs.orchestration.simulation import Simulation
 from thrs.simulation.fmu import Fmu
@@ -69,12 +73,14 @@ class Runner[S: ThrsValues, C: ThrsValues, P: ThrsValues, M: ThrsValues]:
 
     def __init__(
         self,
-        connector: Connector[S, C],
+        control_connector: MqttConnector,
+        simulation_connector: MqttSimulationConnector | None,
         control: Control[S, C, P, M],
         alarms: BaseAlarms[S, C, P],
     ):
         self._control = control
-        self._connector = connector
+        self._control_connector = control_connector
+        self._simulation_connector = simulation_connector
         self._alarms = alarms
         self._control_values = self._control.initial()
 
@@ -92,10 +98,20 @@ class Runner[S: ThrsValues, C: ThrsValues, P: ThrsValues, M: ThrsValues]:
 
     async def run(self, n_ticks: int) -> None:
         for _ in range(n_ticks):
-            sensor_values = await self._connector.transceive(self._control_values)
-            self._control_values = self._control.control(sensor_values)
+            sensor_values = await self._control_connector.transceive(
+                self._control_values  # type:ignore
+            )
+            if self._simulation_connector:
+                # If there is a simulation, we run it and use its sensor values
+                sensor_values = await self._simulation_connector.transceive(
+                    self._control_values  # type:ignore
+                )
+
+            self._control_values = self._control.control(sensor_values)  # type:ignore
             alarms = self._alarms.check(
-                sensor_values, self._control_values, self._control.parameters
+                sensor_values,  # type:ignore
+                self._control_values,  # type:ignore
+                self._control.parameters,
             )
             if alarms:
                 warnings.warn(

--- a/zero-thrs-control/tests/orchestration/test_connector.py
+++ b/zero-thrs-control/tests/orchestration/test_connector.py
@@ -21,7 +21,7 @@ from thrs.orchestration.connector import (
     DirectMqttMapping,
     ModuleMqttMapping,
     MqttConnector,
-    MqttControlConnector,
+    MqttSimulationConnector,
     PartialMqttMapping,
 )
 
@@ -170,24 +170,18 @@ class TestCombinedMqttMapping:
         )
 
 
-async def _mqtt_client(settings):
+@pytest.fixture
+async def mqtt_client(settings):
     async with Client(settings.mqtt_host, settings.mqtt_port) as client:
         yield client
 
 
-mqtt_client = pytest.fixture(_mqtt_client)
-mqtt_client2 = pytest.fixture(_mqtt_client)
-
-
-async def test_mqtt_connector(mqtt_client, mqtt_client2):
-    connector = MqttConnector(
+async def test_mqtt_simulation_connector(mqtt_client):
+    connector = MqttSimulationConnector(
         SimpleSimulation(datetime.now()),
         mqtt_client,
-        mqtt_client2,
         "test_devices_topic_prefix",
-        "test_controller_topic_prefix",
         "test_simulation_topic_prefix",
-        {"simple": SimpleInOut},
         {"simple": SimpleInOut},
         SimpleInOut,
     )
@@ -236,7 +230,7 @@ def mock_mqtt_client() -> mock.AsyncMock:
     mock_mqtt_client = mock.AsyncMock(Client)
 
     async def receive_messages(
-        connector: MqttControlConnector, messages: dict[str, ThrsValues]
+        connector: MqttConnector, messages: dict[str, ThrsValues]
     ):
         async def return_messages():
             for topic, payload in messages.items():
@@ -272,7 +266,7 @@ async def test_mqttcontrol_connector(mock_mqtt_client):
      - that the suffixes are correct
      - That sending and receiving (in order) is correct
     """
-    connector = MqttControlConnector(
+    connector = MqttConnector(
         mock_mqtt_client,
         "devices_topic_prefix",
         "controller_topic_prefix",

--- a/zero-thrs-control/tests/orchestration/test_runner.py
+++ b/zero-thrs-control/tests/orchestration/test_runner.py
@@ -12,8 +12,12 @@ from thrs.orchestration.runner import Runner
 async def test_simulator():
     control = SimpleControl(SimpleParameters(), lambda: datetime.now())
     connector = SimpleConnector()
-    runner = Runner(connector, control, SimpleAlarms())
+    simulation_connector = SimpleConnector()
+    runner = Runner(connector, simulation_connector, control, SimpleAlarms())  # type: ignore
     await runner.run(3)
     assert len(connector.controls) == 3
     assert connector.controls[0].go_with_the.flow.value == 0
     assert connector.controls[0].go_with_the.temperature.value == 0
+    assert len(simulation_connector.controls) == 3
+    assert simulation_connector.controls[0].go_with_the.flow.value == 0
+    assert simulation_connector.controls[0].go_with_the.temperature.value == 0


### PR DESCRIPTION
The result is a bit ugly right now, but this leaves space for "ControllerValues". Values like ControlMode that are published by control modules but not as part of command of lower devices. This also includes stuff like the tank controller state