### PR TITLE
Fix timout during manual control

### DIFF
--- a/zero-thrs-control/.vscode/launch.json
+++ b/zero-thrs-control/.vscode/launch.json
@@ -26,6 +26,19 @@
       "cwd": "${workspaceFolder}",
     },
     {
+      "name": "THRS: Debug simulation dhw",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "thrs.cli",
+      "args": [
+        "run",
+        "dhw"
+      ],
+      "console": "integratedTerminal",
+      "justMyCode": false,
+      "cwd": "${workspaceFolder}",
+    },
+    {
       "name": "THRS: Debug graphql api",
       "type": "debugpy",
       "request": "launch",

--- a/zero-thrs-control/src/thrs/control/switching.py
+++ b/zero-thrs-control/src/thrs/control/switching.py
@@ -42,6 +42,7 @@ class SwitchingControl[
         self._manual_control = manual
         self._automatic_control = automatic
         self._mode: Literal["manual", "automatic"] = "manual"
+        _, self._last_controller_state = self.initial()
 
     def initial(
         self,
@@ -56,9 +57,12 @@ class SwitchingControl[
     ) -> tuple[ControlValues, ControllerState]:
         if self._mode == "manual":
             control_values, _ = self._manual_control.control(sensor_values)
-            return control_values, EmptyControllerState()  # type: ignore
+            return control_values, self._last_controller_state
         else:
-            return self._automatic_control.control(sensor_values)
+            control_values, self._last_controller_state = (
+                self._automatic_control.control(sensor_values)
+            )
+            return control_values, self._last_controller_state
 
     def switch_mode(self, mode: Literal["manual", "automatic"]):
         self._mode = mode


### PR DESCRIPTION
the api expects contollervalues to be complete/filled so we cannot send empty state and just send the last state