### PR TITLE
Fix High Temperatur sim tab missing on Thrsim

### DIFF
--- a/zero-ui/src/modules/thrs/stores/simulation.ts
+++ b/zero-ui/src/modules/thrs/stores/simulation.ts
@@ -40,7 +40,11 @@ export const useSimulationStore = defineStore("simulation", () => {
   const { data } = toRefs(useThrsHistory());
   const activeSimulation = computed(() => data.value?.simulation?.inputs?.__typename);
   const activeSimulationType = computed(() =>
-    SIMULATION_TYPES.find((type) => activeSimulation.value?.toLocaleLowerCase().startsWith(type)),
+    SIMULATION_TYPES.find((type) =>
+      `${activeSimulation.value?.charAt(0)?.toLowerCase()}${activeSimulation.value?.slice(1)}`.startsWith(
+        type,
+      ),
+    ),
   );
 
   const statusQuery = useQuery<SimulationStatus>({


### PR DESCRIPTION
The mapping contains "highTemperature" and thus blanket lowercase is not working... using a similar ugly construct that is used in other places to match logic

Also I expect this needs changes in the future to work with cosimulation